### PR TITLE
Normalize text and add divisions

### DIFF
--- a/1_sanskr/tei/sa_kAlidAsa-meghadUta-edkale.xml
+++ b/1_sanskr/tei/sa_kAlidAsa-meghadUta-edkale.xml
@@ -306,863 +306,863 @@
 
 <text xml:lang="sa-Latn">
   <body>
-
-<p>kaścit kāntāvirahaguruṇā svādhikārāt pramattaḥ $
-<lg>
-<l>śāpenāstaṃgamitamahimā varṣabhogyeṇa bhartuḥ &amp;</l>
-<l>yakṣaś cakre janakatanayāsnānapuṇyodakeṣu %</l>
-<l>snigdhacchāyātaruṣu vasatiṃ rāmagiryāśrameṣu // 1.1 //</l>
-</lg></p>
-
-<p>tasminn adrau katicid abalāviprayuktaḥ sa kāmī $
-<lg>
-<l>nītvā māsān kanakavalayabhraṃśariktaprakoṣṭhaḥ &amp;</l>
-<l>āṣāḍhasya prathamadivase megham āśliṣṭasānuṃ %</l>
-<l>vaprakrīḍāpariṇatagajaprekṣaṇīyaṃ dadarśa // 1.2 //</l>
-</lg></p>
-
-<p>tasya sthitvā katham api puraḥ kautukādhānahetor $
-<lg>
-<l>antarbāṣpaś ciram anucaro rājarājasya dadhyau &amp;</l>
-<l>meghāloke bhavati sukhino 'py anyathāvṛtti cetaḥ %</l>
-<l>kaṇṭhāśleṣapraṇayini jane kiṃ punar dūrasaṃsthe // 1.3 //</l>
-</lg></p>
-
-<p>pratyāsanne nabhasi dayitājīvitālambanārthī $
-<lg>
-<l>jīmūtena svakuśalamayīṃ hārayiṣyan pravṛttim &amp;</l>
-<l>sa pratyagraiḥ kuṭajakusumaiḥ kalpitārghāya tasmai %</l>
-<l>prītaḥ prītipramukhavacanaṃ svāgataṃ vyājahāra // 1.4 //</l>
-</lg></p>
-
-<p>dhūmajyotiḥsalilamarutāṃ saṃnipātaḥ kva meghaḥ $
-<lg>
-<l>sandeśārthāḥ kva paṭukaraṇaiḥ prāṇibhiḥ prāpaṇīyāḥ &amp;</l>
-<l>ity autsukyād aparigaṇayan guhyakas taṃ yayāce %</l>
-<l>kāmārtā hi prakṛtikṛpaṇāś cetanācetaeṣu // 1.5 //</l>
-</lg></p>
-
-<p>jātaṃ vaṃśe bhuvanavidite puṣkarāvartakānāṃ $
-<lg>
-<l>jānāmi tvāṃ prakṛtipuruṣaṃ kāmarūpaṃ maghonaḥ &amp;</l>
-<l>tenārthitvaṃ tvayi vidhivaśād dūrabandhur gato 'haṃ %</l>
-<l>yācñā moghā varam adhiguṇe nādhame labdhakāmā // 1.6 //</l>
-</lg></p>
-
-<p>saṃtaptānāṃ tvamasi śaraṇaṃ tat payoda priyāyāḥ $
-<lg>
-<l>saṃdeśaṃ me hara dhanapatikrodhaviśleṣitasya &amp;</l>
-<l>gantavyā te vasatir alakā nāma yakṣeśvarāṇāṃ %</l>
-<l>bāhyodyānasthitaharaśiraścandrikādhautaharmyā // 1.7 //</l>
-</lg></p>
-
-<p>tvām ārūḍhaṃ pavanapadavīm udgṛhītālakāntāḥ $
-<lg>
-<l>prekṣiṣyante pathikavanitāḥ pratyayād āśvasantyaḥ &amp;</l>
-<l>kaḥ saṃnaddhe virahavidhurāṃ tvayy upekṣeta jāyāṃ %</l>
-<l>na syād anyo 'py aham iva jano yaḥ parādhīnavṛttiḥ // 1.8 //</l>
-</lg></p>
-
-<p>tvāṃ cāvaśyaṃ divasagaṇanātatparām ekapatnīm $
-<lg>
-<l>avyāpannām avihatagatir drakṣyasi bhrātṛjāyām &amp;</l>
-<l>āśābandhaḥ kusumasadṛśaṃ prāyaśo hy aṅganānāṃ %</l>
-<l>sadyaḥ pāti praṇayi hṛdayaṃ viprayoge ruṇaddhi // 1.9 //</l>
-</lg></p>
-
-<p>mandaṃ mandaṃ nudati pavanaś cānukūlo yathā tvāṃ $
-<lg>
-<l>vāmaś cāyaṃ nadati madhuraṃ cātakas te sagandhaḥ &amp;</l>
-<l>garbhādhānakṣaṇaparicayān nūnam ābaddhamālāḥ %</l>
-<l>seviṣyante nayanasubhagaṃ khe bhavantaṃ balākāḥ // 1.10 //</l>
-</lg></p>
-
-<p>kartuṃ yac ca prabhavati mahīm ucchilīndhrām avandhyāṃ $
-<lg>
-<l>tac chrutvā te śravaṇasubhagaṃ garjitaṃ mānasotkāḥ &amp;</l>
-<l>ā kailāsād bisakisalayacchedapātheyavantaḥ %</l>
-<l>saṃpatsyante nabhasi bhavato rājahaṃsāḥ sahāyāḥ // 1.11 //</l>
-</lg></p>
-
-<p>āpṛcchasva priyasakham amuṃ tuṅgam āliṅgya śailaṃ $
-<lg>
-<l>vandyaiḥ puṃsāṃ raghupatipadair aṅkitaṃ mekhalāsu &amp;</l>
-<l>kāle kāle bhavati bhavato yasya saṃyogam etya %</l>
-<l>snehavyaktiś ciravirahajaṃ muñcato bāṣpamuṣṇam // 1.12 //</l>
-</lg></p>
-
-<p>margaṃ tāvac chṛṇu kathayatas tvatprayāṇānurūpaṃ $
-<lg>
-<l>saṃdeśaṃ me tadanu jalada śroṣyasi śrotrapeyam &amp;</l>
-<l>khinnaḥ khinnaḥ śihariṣu padaṃ nyasya gantāsi yatra %</l>
-<l>kṣīṇaḥ kṣīṇaḥ parilaghu payaḥ srotasāṃ copabhujya // 1.13 //</l>
-</lg></p>
-
-<p>adreḥ śṛṅgaṃ harati pavanaḥ kiṃ svid ity unmukhībhir $
-<lg>
-<l>dṛṣṭotsāhaś cakitacakitaṃ mugdhasiddhāṅganābhiḥ &amp;</l>
-<l>sthānād asmāt sarasaniculād utpatodaṅmukhaḥ khaṃ %</l>
-<l>diṅnāgānāṃ pathi pariharan sthūlahastāvalepān // 1.14 //</l>
-</lg></p>
-
-<p>ratnacchāyāvyatikara iva prekṣyametatpurastād $
-<lg>
-<l>valmīkāgrāt prabhavati dhanuḥkhaṇḍam ākhaṇḍalasya &amp;</l>
-<l>yena śyāmaṃ vapur atitarāṃ kāntim āpatsyate te %</l>
-<l>barheṇeva sphuritarucinā gopaveṣasya viṣṇoḥ // 1.15 //</l>
-</lg></p>
-
-<p>tvayy āyantaṃ kṛṣiphalam iti bhrūvikārān abhijñaiḥ $
-<lg>
-<l>prītisnigdhairjanapadavadhūlocanaiḥ pīyamānaḥ &amp;</l>
-<l>sadyaḥsīrotkaṣaṇasurabhi kṣetram āruhya mālaṃ %</l>
-<l>kiṃcit paścād vraja laghugatir bhūya evottareṇa // 1.16 //</l>
-</lg></p>
-
-<p>tvām āsārapraśamitavanopaplavaṃ sādhu mūrdhnā $
-<lg>
-<l>vakṣyaty adhvaśramaparigataṃ sānumān āmrakūṭaḥ &amp;</l>
-<l>na kṣudro 'pi prathamasukṛtāpekṣayā saṃśrayāya %</l>
-<l>prāpte mitre bhavati vimukhaḥ kiṃ punar yas tatthoccaiḥ // 1.17 //</l>
-</lg></p>
-
-<p>channopāntaḥ pariṇataphaladyotibhiḥ kānanāmrais $
-<lg>
-<l>tvayy ārūḍhe śikharam acalaḥ snigdhaveṇīsavarṇe &amp;</l>
-<l>nūnaṃ yāsyaty amaramithunaprekṣaṇīyām avasthāṃ %</l>
-<l>madhye śyāmaḥ stana iva bhuvaḥ śeṣavistārapāṇḍuḥ // 1.18 //</l>
-</lg></p>
-
-<p>sthitvā tasmin vanacaravadhūbhuktakuñje muhūrtaṃ $
-<lg>
-<l>toyotsargadrutataragatis tatparaṃ vartma tīrṇaḥ &amp;</l>
-<l>revāṃ drakṣyasy upalaviṣame vindhyapāde viśīrṇāṃ %</l>
-<l>bhakticchedair iva viracitāṃ bhūtim aṅge gajasya // 1.19 //</l>
-</lg></p>
-
-<p>{adhvaklāntaṃ pratimukhagataṃ sānumānāmrakūṭas $
-<lg>
-<l>tuṅgena tvāṃ jalada śirasā vakṣyati ślāghamānaḥ &amp;</l>
-<l>āsāreṇa tvam api śamayes tasya naidāgham agniṃ %</l>
-<l>sadbhāvārdraḥ phalati na cireṇopakāro mahatsu // 1.19a} //</l>
-</lg></p>
-
-<p>tasyās tiktair vanagajamadair vāsitaṃ vāntavṛṣṭir $
-<lg>
-<l>jambūkuñjapratihatarayaṃ toyam ādāya gaccheḥ &amp;</l>
-<l>antaḥsāraṃ ghana tulayituṃ nānilaḥ śakṣyati tvāṃ %</l>
-<l>riktaḥ sarvo bhavati hi laghuḥ pūrṇatā gauravāya // 1.20 //</l>
-</lg></p>
-
-<p>nīpaṃ dṛṣṭvā haritakapiśaṃ kesarair ardharūḍhair $
-<lg>
-<l>āvirbhūtaprathamamukulāḥ kandalīś cānukaccham &amp;</l>
-<l>jagdhvāraṇyeṣv adhikasurabhiṃ gandham āghrāya corvyāḥ %</l>
-<l>sāraṅgās te jalalavamucaḥ sūcayiṣyanti mārgam // 1.21 //</l>
-</lg></p>
-
-<p>ambhobindugrahaṇacaturāṃś cātakān vīkṣamāṇāḥ $
-<lg>
-<l>śreṇībhūtāḥ parigaṇanayā nirdiśanto balākāḥ &amp;</l>
-<l>tvām āsādya stanitasamaye mānayiṣyanti siddhāḥ %</l>
-<l>sotkampāni priyasahacarīsaṃbhramāliṅgitāni // 1.22 //</l>
-</lg></p>
-
-<p>utpaśyāmi drutamapi sakhe matpriyārthaṃ yiyāsoḥ $
-<lg>
-<l>kālakṣepaṃ kakubhasurabhau parvate parvete te &amp;</l>
-<l>śuklāpāṅgaiḥ sajalanayanaiḥ svāgatīkṛtya kekāḥ %</l>
-<l>pratudyātaḥ katham api bhavān gantum āśu vyavasyet // 1.23 //</l>
-</lg></p>
-
-<p>pāṇḍucchāyopavanavṛtayaḥ ketakaiḥ sūcibhinnair $
-<lg>
-<l>nīḍārambhair gṛhabalibhujām ākulagrāmacaityāḥ &amp;</l>
-<l>tvayy āsanne pariṇataphalaśyāmajambūvanāntāḥ %</l>
-<l>saṃpatsyante katipayadinasthāyihaṃsā daśārṇāḥ // 1.24 //</l>
-</lg></p>
-
-<p>teṣāṃ dikṣu prathitavidiśālakṣaṇāṃ rājadhānīṃ $
-<lg>
-<l>gatvā sadyaḥ phalam avikalaṃ kāmukatvasya labdhā &amp;</l>
-<l>tīropāntastanitasubhagaṃ pāsyasi svādu yasmāt %</l>
-<l>sabhrūbhaṅgaṃ mukham iva payo vetravatyāś calormi // 1.25 //</l>
-</lg></p>
-
-<p>nīcairākhyaṃ girim adhivases tatra viśrāmahetos $
-<lg>
-<l>tvatsamparkāt pulakitam iva prauḍhapuṣpaiḥ kadambaiḥ &amp;</l>
-<l>yaḥ puṇyastrīratiparimalodgāribhir nāgarāṇām %</l>
-<l>uddāmāni prathayati śilāveśmabhir yauvanāni // 1.26 //</l>
-</lg></p>
-
-<p>viśrāntaḥ san vraja vananadītīrajānāṃ niṣiñcann $
-<lg>
-<l>udyānānāṃ navajalakaṇair yūthikājālkāni &amp;</l>
-<l>gaṇḍasvedāpanayanarujāklāntakarṇotpalānāṃ %</l>
-<l>chāyādānāt kṣaṇaparicitaḥ puṣpalāvīmukhānām // 1.27 //</l>
-</lg></p>
-
-<p>vakraḥ panthā yadapi bhavataḥ prasthitasyottarāśāṃ $
-<lg>
-<l>saudhotsaṅgapraṇayavimukho mā sma bhūr ujjayinyāḥ &amp;</l>
-<l>vidyuddāmasphuritacakritais tatra paurāṅganānāṃ %</l>
-<l>lolāpāṅgair yadi na ramase locanair vañcito 'si // 1.28 //</l>
-</lg></p>
-
-<p>vīcikṣobhastanitavihagaśreṇikāñcīguṇāyāḥ $
-<lg>
-<l>saṃsarpantyāḥ skhalitasubhagaṃ darśitāvartanābhaḥ &amp;</l>
-<l>nirvindhyāyāḥ pathi bhava rasābhyantaraḥ saṃnipatya %</l>
-<l>strīṇām ādyaṃ praṇayavacanaṃ vibhramo hi priyeṣu // 1.29 //</l>
-</lg></p>
-
-<p>veṇībhūtapratanusalilā tām atītasya sindhuḥ $
-<lg>
-<l>pāṇḍucchāyā taṭaruhatarubhraṃśibhirjīrṇaparṇaiḥ &amp;</l>
-<l>saubhāgyaṃ te subhaga virahāvasthayā vyañjayantī %</l>
-<l>kārśyaṃ yena tyajati vidhinā sa tvayaivopapādyaḥ // 1.30 //</l>
-</lg></p>
-
-<p>prāpyāvantīn udayanakathākovidagrāmavṛddhān $
-<lg>
-<l>pūrvoddiṣṭām upasara purīṃ śrīviśālāṃ viśālām &amp;</l>
-<l>svalpībhūte sucaritaphale svargiṇāṃ gāṃ gatānāṃ %</l>
-<l>śeṣaiḥ puṇyair hṛtam iva divaḥ kāntimat khaṇḍam ekam // 1.31 //</l>
-</lg></p>
-
-<p>dīrghīkurvan paṭu madakalaṃ kūjitaṃ sārasānāṃ $
-<lg>
-<l>pratyūṣeṣu sphuṭitakamalāmodamaitrīkaṣāyaḥ &amp;</l>
-<l>yatra strīṇāṃ harati surataglānim aṅgānukūlaḥ %</l>
-<l>śiprāvātaḥ priyatama iva prārthanācāṭukāraḥ // 1.32 //</l>
-</lg></p>
-
-<p>hārāṃs tārāṃs taralaguṭikān koṭiśaḥ śaṅkaśuktīḥ $
-<lg>
-<l>śaṣpaśyāmān marakatamaṇīn unmayūkhaprarohān &amp;</l>
-<l>dṛṣṭvā yasyāṃ vipaṇiracitān vidrumāṇāṃ ca bhaṅgān %</l>
-<l>saṃlakṣyante salilanidhayas toyamātrāvaśeṣāḥ // 1.33 //</l>
-</lg></p>
-
-<p>pradyotasya priyaduhitaraṃ vatsarājo 'tra jahre $
-<lg>
-<l>haimaṃ tāladrumavanam abhūd atra tasyaiva rājñaḥ &amp;</l>
-<l>atrodbhrāntaḥ kila nalagiriḥ stambham utpāṭya darpād %</l>
-<l>ity āgantūn ramayati jano yatra bandhūn abhijñaḥ // 1.34 //</l>
-</lg></p>
-
-<p>jālodgīrṇair upacitavapuḥ keśasaṃskāradhūpair $
-<lg>
-<l>bandhuprītyā bhavanaśikhjibhir dattanṛtyopahāraḥ &amp;</l>
-<l>harmyeṣv asyāḥ kusumasurabhiṣv adhavakhedaṃ nayethā %</l>
-<l>lakṣmīṃ paśyaṃl lalitavanitāpādarāgāṅkiteṣu // 1.35 //</l>
-</lg></p>
-
-<p>bhartuḥ kaṇṭhacchavir iti gaṇaiḥ sādaraṃ vīkṣyamāṇaḥ $
-<lg>
-<l>puṇyaṃ yāyās tribhuvanaguror dhāma caṇḍīśvarasya &amp;</l>
-<l>dhūtodyānaṃ kuvalayarajogandhibhir gandhavatyās %</l>
-<l>toyakrīḍāniratayuvatisnānatiktair marudbhiḥ // 1.36 //</l>
-</lg></p>
-
-<p>apy anyasmiñ jaladhara mahākālam āsādya kāle $
-<lg>
-<l>sthātavyaṃ te nayanaviṣayaṃ yāvad atyeti bhānuḥ &amp;</l>
-<l>kurvan sandhyāvalipaṭahatāṃ śūlinaḥ ślāghanīyām %</l>
-<l>āmandrāṇāṃ phalam avikalaṃ lapsyase garjitānām // 1.37 //</l>
-</lg></p>
-
-<p>pādanyāsaiḥ kvaṇitaraśanās tatra līlāvadhūtai $
-<lg>
-<l>ratnacchāyākhacitavalibhiś cāmaraiḥ klāntahastāḥ &amp;</l>
-<l>veśyās tvatto nakhapadasukhān prāpya varṣāgrabindūn %</l>
-<l>āmokṣyante tvayi madhukaraśreṇidīrghān kaṭakṣān // 1.38 //</l>
-</lg></p>
-
-<p>paścād uccairbhujataruvanaṃ maṇḍalenābhlīnaḥ $
-<lg>
-<l>sāṃdhyaṃ tejaḥ pratinavajapāpuṣparaktaṃ dadhānaḥ &amp;</l>
-<l>nṛttārambhe hara paśupater ārdranāgājinecchāṃ %</l>
-<l>śāntodvegastimitanayanaṃ dṛṣṭabhaktir bhavānyā // 1.39 //</l>
-</lg></p>
-
-<p>gacchantīnāṃ ramāṇavasatiṃ yoṣitāṃ tatra naktaṃ $
-<lg>
-<l>ruddhāloke narapatipathe sūcibhedyais tamobhiḥ &amp;</l>
-<l>saudāmanyā kanakanikaṣasnigdhayā darśayorvīṃ %</l>
-<l>toyotsargastanitamuharo mā ca bhūrviklavāstāḥ // 1.40 //</l>
-</lg></p>
-
-<p>tāṃ kasyāṃcid bhavanavalabhau suptapārāvatāyāṃ $
-<lg>
-<l>nītvā rātriṃ ciravilasanāt khinnavidyutkalatraḥ &amp;</l>
-<l>dṛṣṭe sūrye punarapi bhavān vāhayedadhvaśeṣaṃ %</l>
-<l>mandāyante na khalu suhṛdāmabhyupatārthakṛtyāḥ // 1.41 //</l>
-</lg></p>
-
-<p>tasmin kāle nayanasaliaṃ yoṣitāṃ khaṇḍitānāṃ $
-<lg>
-<l>śāntiṃ neyaṃ praṇayibhir ato vartma bhānos tyajāśu &amp;</l>
-<l>prāleyāstraṃ kamalavadanāt so.api hartuṃ nalinyāḥ %</l>
-<l>pratyāvṛttastvayi kararudhi syādanalpabhyasūyaḥ // 1.42 //</l>
-</lg></p>
-
-<p>gambhīrāyāḥ payasi saritaś cetasīva prasanne $
-<lg>
-<l>chāyātmāpi prakṛtisubhago lapsyate te praveśam &amp;</l>
-<l>tasmād asyāḥ kumudaviśadāny arhasi tvaṃ na dhairyān %</l>
-<l>moghīkartuṃ caṭulaśaphorodvartanaprekṣitāni // 1.43 //</l>
-</lg></p>
-
-<p>tasyāḥ kiṃcit karadhṛtam iva prāptvāīraśākhaṃ $
-<lg>
-<l>hṛtvā nīlaṃ salilavasanaṃ muktarodhonitambam &amp;</l>
-<l>prasthānaṃ te katham api sakhe lambamānasya bhāvi %</l>
-<l>jñātāsvādo vivṛtajaghanāṃ ko vihātuṃ samarthā // 1.44 //</l>
-</lg></p>
-
-<p>tvanniṣyandocchvasitavasudhāgandhasamparkaramyaḥ $
-<lg>
-<l>srotorandhradhvanitasubhagaṃ dantibhiḥ pīyamānaḥ &amp;</l>
-<l>nīcair vāsyaty upajigamiṣor devapūrvaṃ giriṃ te %</l>
-<l>śīto vāyuḥ pariṇamayitā kānanodumbarāṇām // 1.45 //</l>
-</lg></p>
-
-<p>tatra skandaṃ niyatavasatiṃ puṣpameghīkṛtātmā $
-<lg>
-<l>puṣpāsāraiḥ snapayatu bhavān vyomagaṅgājalārdraiḥ &amp;</l>
-<l>rakṣāhetor navaśaśibhṛtā vāsavīnāṃ camūnām %</l>
-<l>atyādityaṃ hutavahamukhe saṃbhṛtaṃ tad dhi teyaḥ // 1.46 //</l>
-</lg></p>
-
-<p>jyotirlekhāvalayi galitaṃ yasya barhaṃ bhavānī $
-<lg>
-<l>putrapremṇā kuvalayadalaprāpi karṇe karoti &amp;</l>
-<l>dhautāpāṅgaṃ haraśaśirucā pāvakes taṃ mayūraṃ %</l>
-<l>paścād adrigrahaṇagurubhir garjitair nartayethāḥ // 1.47 //</l>
-</lg></p>
-
-<p>ārādyainaṃ śaravaṇabhavaṃ devam ullaṅghitādhvā $
-<lg>
-<l>siddhadvandvair jalakaṇabhayād vīṇibhir muktamārgaḥ &amp;</l>
-<l>vyālambethāḥ surabhitanayālambhajāṃ mānayiṣyan %</l>
-<l>srotomūrtyā bhuvi pariṇatāṃ rantidevasya kīrtim // 1.48 //</l>
-</lg></p>
-
-<p>tvayy ādātuṃ jalam avanate śārṅgiṇo varṇacaure $
-<lg>
-<l>tasyāḥ sindhoḥ pṛthum api tanuṃ dūrabhāvāt pravāham &amp;</l>
-<l>prekṣiṣyante gaganagatayo nūnam āvarjya dṛṣṭir %</l>
-<l>ekaṃ bhuktāguṇam iva bhuvaḥ sthūlamadhyendranīlam // 1.49 //</l>
-</lg></p>
-
-<p>tām uttīrya vraja paricitabhrūlatāvibhramāṇāṃ $
-<lg>
-<l>pakṣmotkṣepād uparivilasatkṛṣṇaśāraprabhāṇām &amp;</l>
-<l>kundakṣepānugamadhukaraśrīmuṣām ātmabimbaṃ %</l>
-<l>pātrīkurvan daśapuravadhūnetrakautūhalānām // 1.50 //</l>
-</lg></p>
-
-<p>brahmāvartaṃ janapadam atha cchāyayā gāhamānaḥ $
-<lg>
-<l>kṣetraṃ kṣatrapradhanapiśunaṃ kauravaṃ tad bhajethāḥ &amp;</l>
-<l>rājanyānāṃ śitaśaraśatair yatra gāṇḍīvadhanvā %</l>
-<l>dhārāpātais tvam iva kamalāny abhyavarṣan mukhāni // 1.51 //</l>
-</lg></p>
-
-<p>hitvā hālām abhimatarasāṃ revatīlocanāṅkāṃ $
-<lg>
-<l>bandhuprītyā samaravimukho lāṅgalī yāḥ siṣeve &amp;</l>
-<l>kṛtvā tāsām adhigamam apāṃ saumya sārasvatīnām %</l>
-<l>antaḥ śuddhas tvam api bhavitā varṇamātreṇa kṛṣṇaḥ // 1.52 //</l>
-</lg></p>
-
-<p>tasmād gaccher anukanakhalaṃ śailarājāvatīrṇāṃ $
-<lg>
-<l>jāhnoḥ kanyāṃ sagaratanayasvargasopānapaṅktim &amp;</l>
-<l>gaurīvaktrabhrukuṭiracanāṃ yā vihasyeva phenaiḥ %</l>
-<l>śambhoḥ keśagrahaṇam akarod indulagnormihastā // 1.53 //</l>
-</lg></p>
-
-<p>tasyāḥ pātuṃ suragaja iva vyomni paścārdhalambī $
-<lg>
-<l>tvaṃ ced acchasphaṭikaviśadaṃ tarkayes tiryag ambhaḥ &amp;</l>
-<l>saṃsarpantyā sapadi bhavataḥ srotasi cchāyayāsau %</l>
-<l>syād asthānopagatayamunāsaṃgamevābhirāmā // 1.54 //</l>
-</lg></p>
-
-<p>āsīnānāṃ surabhitaśilaṃ nābhigandhair mṛgāṇāṃ $
-<lg>
-<l>tasyā eva prabhavam acalaṃ prāpya gauraṃ tuṣāraiḥ &amp;</l>
-<l>vakṣyasy adhvaśramavinayena tasya śṛṅge niṣaṇṇaḥ %</l>
-<l>śobhāṃ śubhrāṃ trinayanavṛṣotkhātapaṅkopameyam // 1.55 //</l>
-</lg></p>
-
-<p>taṃ ced vāyau sarati saralaskandhasaṃghaṭṭajanmā $
-<lg>
-<l>bādhetolkākṣapitacamarībālabhāro davāgniḥ &amp;</l>
-<l>arhasy enaṃ śamayitum alaṃ vāridhārāsahasrair %</l>
-<l>āpannārtipraśamanaphalāḥ saṃpado hy uttamānām // 1.56 //</l>
-</lg></p>
-
-<p>ye saṃrambhotpatanarabhasāḥ svāṅgabhaṅgāya tasmin $
-<lg>
-<l>muktādhvānaṃ sapadi śarabhā laṅghayeyur bhavantam &amp;</l>
-<l>tān kurvīthās tumulakarakāvṛṣṭipātāvakīrṇan %</l>
-<l>ke vā na syuḥ paribhavapadaṃ niṣphalārambhayatnāḥ // 1.57 //</l>
-</lg></p>
-
-<p>tatra vyaktaṃ dṛṣadi caraṇanyāsam ardhendumauleḥ $
-<lg>
-<l>śaśvat siddhair upacitabaliṃ bhaktinamraḥ parīyāḥ &amp;</l>
-<l>yasmin dṛṣṭe karaṇavigamād ūrdhvam uddhūtapāpāḥ %</l>
-<l>kalpiṣyante sthiragaṇapadaprāptaye śraddadhānāḥ // 1.58 //</l>
-</lg></p>
-
-<p>śabdāyante madhuram anilaiḥ kīcakāḥ pūryamāṇāḥ $
-<lg>
-<l>saṃraktābhis tripuravijayo gīyate kiṃnarābhiḥ &amp;</l>
-<l>nirhrādas te muraja iva cet kandareṣu dhvaniḥ syāt %</l>
-<l>saṃgītārtho nanu paśupates tatra bhāvī samagraḥ // 1.59 //</l>
-</lg></p>
-
-<p>prāleyādrer upataṭam atikramya tāṃs tān viśeṣān $
-<lg>
-<l>haṃsadvāraṃ bhṛgupatiyaśovartma yat krauñcarandhram &amp;</l>
-<l>tenodīcīṃ diśam anusares tiryag āyāmaśobhī %</l>
-<l>śyāmaḥ pādo baliniyamanābhyudyatasyeva viṣṇoḥ // 1.60 //</l>
-</lg></p>
-
-<p>gatvā cordhvaṃ daśamukhabhujocchvāsitaprasthasaṃdheḥ $
-<lg>
-<l>kailāsasya tridaśavanitādarpaṇasyātithiḥ syāḥ &amp;</l>
-<l>śṛṅgocchrāyaiḥ kumudaviśadair yo vitatya sthitaḥ khaṃ %</l>
-<l>rāśībhūtaḥ pratidinam iva tryambakasyaṭṭahāsaḥ // 1.61 //</l>
-</lg></p>
-
-<p>utpaśyāmi tvayi taṭagate snigdhabhinnāñjanābhe $
-<lg>
-<l>sadyaḥ kṛttadviradadaśanacchedagaurasya tasya &amp;</l>
-<l>śobhām adreḥ stimitanayanaprekṣaṇīyāṃ bhavitrīm %</l>
-<l>aṃsanyaste sati halabhṛto mecake vāsasīva // 1.62 //</l>
-</lg></p>
-
-<p>hitvā tasmin bhujagavalayaṃ śambhunā dattahastā $
-<lg>
-<l>krīḍāśaile yadi ca vicaret pādacāreṇa gaurī &amp;</l>
-<l>bhaṅgībhaktyā viracitavapuḥ stambhitāntarjalaughaḥ %</l>
-<l>sopānatvaṃ kuru maṇitaṭārohaṇāyāgrayāyī // 1.63 //</l>
-</lg></p>
-
-<p>tatrāvaśyaṃ valayakuliśoddhaṭṭanodgīrṇatoyaṃ $
-<lg>
-<l>neṣyanti tvāṃ surayuvatayo yantradhārāgṛhatvam &amp;</l>
-<l>tābhyo mokṣas tava yadi sakhe gharmalabdhasya na syāt %</l>
-<l>krīḍālolāḥ śravaṇaparuṣair garjitair bhāyayes tāḥ // 1.64 //</l>
-</lg></p>
-
-<p>hemāmbhojaprasavi salilaṃ mānasasyādadānaḥ $
-<lg>
-<l>kurvan kāmaṃ kṣaṇamukhapaṭaprītim airāvatasya &amp;</l>
-<l>dhunvan kalpadrumakisalayān yaṃśukānīva vātair %</l>
-<l>nānāceṣṭair jaladalalitair nirviśes taṃ nagendram // 1.65 //</l>
-</lg></p>
-
-<p>tasyotsaṅge praṇayina iva srastagaṅgādukūlāṃ $
-<lg>
-<l>na tvaṃ dṛṣṭvā na punar alakāṃ jñāsyase kāmacārin &amp;</l>
-<l>yā vaḥ kāle vahati salilodgāram uccair vimānā %</l>
-<l>muktājālagrathitam alakaṃ kāminīvābhravṛndam // 1.66 //</l>
-</lg></p>
-
-<p>{ūttarameghaḥ}</p>
-
-<p>vidhunvantaṃ lalitavanitāḥ sendracāpaṃ sacitrāḥ $
-<lg>
-<l>saṃgītāya prahatamurajāḥ snigdhagambhīraghoṣam &amp;</l>
-<l>antastoyaṃ maṇimayabhuvas tuṅgam abhraṃlihāgrāḥ %</l>
-<l>prāsādās tvāṃ tulayitum alaṃ yatra tais tair viśeṣaiḥ // 2.1 //</l>
-</lg></p>
-
-<p>haste līlākamalam alake bālakundānuviddhaṃ $
-<lg>
-<l>nītā lodhraprasavarajasā pāṇḍutām ānane śrīḥ &amp;</l>
-<l>cūḍāpāśe navakuravakaṃ cāru karṇe śirīṣaṃ %</l>
-<l>sīmante ca tvadupagamajaṃ yatra nīpaṃ vadhūnām // 2.2 //</l>
-</lg></p>
-
-<p>yatronmattabhramaramukharāḥ pādapā nityapuṣpā $
-<lg>
-<l>haṃsaśreṇīracitaraśanā nityapadmā nalinyaḥ &amp;</l>
-<l>kekotkaṇṭhā bhuvanaśikhino nityabhāsvatkalāpā %</l>
-<l>nityajyotsnāḥ prahitatamovṛttiramyāḥ pradoṣāḥ // 2.3 //</l>
-</lg></p>
-
-<p>ānandotthaṃ nayanasalilamyatra nānyair nimittair $
-<lg>
-<l>nānyas tāpaṃ kusumaśarajād iṣṭasaṃyogasādhyāt &amp;</l>
-<l>nāpy anyasmāt praṇayakalahād viprayogopapattir %</l>
-<l>vitteśānāṃ na ca khalu vayo yauvanād anyad asti // 2.4 //</l>
-</lg></p>
-
-<p>yasyāṃ yakṣāḥ sitamaṇimayāny etya harmyasthalāni $
-<lg>
-<l>jyotiśchāyākusumaracitāny uttamastrīsahāyāḥ &amp;</l>
-<l>āsevante madhu ratiphalaṃ kalpavṛkṣaprasūtaṃ %</l>
-<l>tvadgambhīradhvaniṣu śanakaiḥ puṣkareṣv āhateṣu // 2.5 //</l>
-</lg></p>
-
-<p>mandākinyāḥ salilaśiśiraiḥ sevyamānā marudbhir $
-<lg>
-<l>mandārāṇām anutaṭaruhāṃ chāyayā vāritoṣṇāḥ &amp;</l>
-<l>anveṣṭavyaiḥ kanakasikatāmuṣṭinikṣepagūḍhaiḥ %</l>
-<l>saṃkrīḍante maṇibhiramaraprārthitayā yatra kanyāḥ // 2.6 //</l>
-</lg></p>
-
-<p>nīvībandhocchvāsitaśithilaṃ yatra bimbādharāṇāṃ $
-<lg>
-<l>kṣaumaṃ rāgādanibhṛtakareṣv ākṣipatsu priyeṣu &amp;</l>
-<l>arcistuṅgān abhimukham api prāpya ratnapradīpān %</l>
-<l>hrīmūḍhānāṃ bhavati viphalapreraṇā cūrṇamuṣṭiḥ // 2.7 //</l>
-</lg></p>
-
-<p>netrā nītāḥ satatagatinā yadvimānāgrabhūmīr $
-<lg>
-<l>ālekhyānāṃ salilakaṇikādoṣam utpādya sadyaḥ &amp;</l>
-<l>śaṅkāspṛṣṭā iva jalamucas tvādṛśā jālamārgair %</l>
-<l>dhūmodgārānukṛtinipuṇā jarjarā niṣpatanti // 2.8 //</l>
-</lg></p>
-
-<p>yatra strīṇāṃ priyatamabhujocchvāsitāliṅgitānām $
-<lg>
-<l>aṅgaglāniṃ suratajanitāṃ tantujālāvalambāḥ &amp;</l>
-<l>tvatsaṃrodhāpagamaviśadaś candrapādair niśīthe %</l>
-<l>vyālumpanti sphuṭajalalavasyandinaś candrakāntāḥ // 2.9 //</l>
-</lg></p>
-
-<p>akṣayyāntarbhavananidhayaḥ pratyahaṃ raktakaṇṭhair $
-<lg>
-<l>udgāyadbhir dhanapatiyaśaḥ kiṃnarair yatra sārdham &amp;</l>
-<l>vaibhrājākhyaṃ vibudhavanitāvāramukhyasahāyā %</l>
-<l>baddhālāpā bahirupavanaṃ kāmino nirviśanti // 2.10 //</l>
-</lg></p>
-
-<p>gatyutkampād alakapatitair yatra mandārapuṣpaiḥ $
-<lg>
-<l>putracchedaiḥ kanakakamalaiḥ karṇavisraṃśibhiś ca &amp;</l>
-<l>muktājālaiḥ stanaparisaracchinnasūtraiś ca hārair %</l>
-<l>naiśo mārgaḥ savitur udaye sūcyate kāminīnām // 2.11 //</l>
-</lg></p>
-
-<p>vāsaś citraṃ madhu nayanayor vibhramādeśadakṣaṃ $
-<lg>
-<l>puṣpodbhedaṃ saha kisalayair bhūṣaṇānāṃ vikalpam &amp;</l>
-<l>lākṣārāgaṃ caraṇakamalanyāsayogyaṃ ca yasyām %</l>
-<l>ekaḥ sūte sakalam abalāmaṇḍanaṃ kalpavṛkṣaḥ // 2.12 //</l>
-</lg></p>
-
-<p>patraśyāmā dinakarahayaspardhino yatra vāhāḥ $
-<lg>
-<l>śailodagrās tvam iva kariṇo vṛṣṭimantaḥ prabhedāt &amp;</l>
-<l>yodhāgraṇyaḥ pratidaśamukhaṃ saṃyuge tasthivāṃsaḥ %</l>
-<l>pratyādiṣṭābharaṇarucayaś candrahāsavraṇāṅkaiḥ // 2.13 //</l>
-</lg></p>
-
-<p>matvā devaṃ dhanapatisakhaṃ yatra sākṣād vasantaṃ $
-<lg>
-<l>prāyaś cāpaṃ na vahati bhayān manmathaḥ ṣaṭpadajyam &amp;</l>
-<l>sabhrūbhaṅgaprahitanayanaiḥ kāmilakṣyeṣv amoghais %</l>
-<l>tasyārambhaś caturavanitāvibhramair eva siddhaḥ // 2.14 //</l>
-</lg></p>
-
-<p>tatrāgāraṃ dhanapatigṛhān uttareṇāsmadīyaṃ $
-<lg>
-<l>dūrāl lakṣyaṃ surapatidhanuścāruṇā toraṇena &amp;</l>
-<l>yasyopānte kṛtakatanayaḥ kāntayā vardhito me %</l>
-<l>hastaprāpyastavakanamito bālamandāravṛkṣaḥ // 2.15 //</l>
-</lg></p>
-
-<p>vāpī cāsmin marakataśilābaddhasopānamārgā $
-<lg>
-<l>haimaiśchannā vikacakamalaiḥ snigdhavaidūryanālaiḥ &amp;</l>
-<l>yasyās toye kṛtavasatayo mānasaṃ saṃnikṛṣṭaṃ %</l>
-<l>nādhyāsyanti vyapagataśucas tvām api prekṣya haṃsāḥ // 2.16 //</l>
-</lg></p>
-
-<p>tasyās tīre racitaśikharaḥ peśalair indranīlaiḥ $
-<lg>
-<l>krīḍāśailaḥ kanakakadalīveṣṭanaprekṣaṇīyaḥ &amp;</l>
-<l>madgehinyāḥ priya iti sakhe cetasā kātareṇa %</l>
-<l>prekṣyopāntasphuritataḍitaṃ tvāṃ tam eva smarāmi // 2.17 //</l>
-</lg></p>
-
-<p>raktāśokaś calakisalayaḥ kesaraś cātra kāntaḥ $
-<lg>
-<l>pratyāsannau kuruvakavṛter mādhavīmaṇḍapasya &amp;</l>
-<l>ekaḥ sakhyās tava saha mayā vāmapādābhilāṣī %</l>
-<l>kāṅkṣaty anyo vadanamadirāṃ dohadacchadmanāsyāḥ // 2.18 //</l>
-</lg></p>
-
-<p>tanmadhye ca sphaṭikaphalakā kāñcanī vāsayaṣṭir $
-<lg>
-<l>mūle baddhā maṇibhir anatiprauḍhavaṃśaprakāśaiḥ &amp;</l>
-<l>tālaiḥ śiñjāvalayasubhagair nartitaḥ kāntayā me %</l>
-<l>yām adhyāste divasavigame nīlakaṇṭhaḥ suhṛd vaḥ // 2.19 //</l>
-</lg></p>
-
-<p>ebhiḥ sādho hṛdayanihitair lakṣaṇair lakṣayethā $
-<lg>
-<l>dvāropānte likhitavapuṣau śaṅkhapadmau ca dṛṣṭvā &amp;</l>
-<l>kṣāmacchāyāṃ bhavanam adhunā madviyogena nūnaṃ %</l>
-<l>sūryāpāye na khalu kamalaṃ puṣyati svāmabhikhyām // 2.20 //</l>
-</lg></p>
-
-<p>gatvā sadyaḥ kalabhatanutāṃ śīghrasaṃpātahetoḥ $
-<lg>
-<l>krīḍāśaile prathamakathite ramyasānau niṣaṇṇaḥ &amp;</l>
-<l>arhasy antarbhavanapatitāṃ kartum alpālpabhāsaṃ %</l>
-<l>khadyotālīvilasitanibhāṃ vidyudunmeṣadṛṣṭim // 2.21 //</l>
-</lg></p>
-
-<p>tanvī śyāmā śikharīdaśanā pakvabimbādharauṣṭhī $
-<lg>
-<l>madhye kṣāmā cakitahariṇīprekṣaṇā nimnanābhiḥ &amp;</l>
-<l>śroṇībhārād alasagamanā stokanamrā stanābhyāṃ %</l>
-<l>yā tatra syād yuvatīviṣaye sṛṣṭir ādyaiva dhātuḥ // 2.22 //</l>
-</lg></p>
-
-<p>tāṃ jānīthāḥ parimitakathāṃ jīvitaṃ me dvitīyaṃ $
-<lg>
-<l>dūrībhūte mayi sahacare cakravākīm ivaikām &amp;</l>
-<l>gāḍhotkaṇṭhāṃ guruṣu divaseṣv eṣu gacchatsu bālāṃ %</l>
-<l>jātāṃ manye śiśiramathitāṃ padminīṃ vānyarūpām // 2.23 //</l>
-</lg></p>
-
-<p>nūnaṃ tasyāḥ prabalaruditocchūnanetraṃ priyāyā $
-<lg>
-<l>niḥśvāsānām aśiśiratayā bhinnavarṇādharoṣṭham &amp;</l>
-<l>hastanyastaṃ mukham asakalavyakti lambālakatvād %</l>
-<l>indor dainyaṃ tvadanusaraṇakliṣṭakānter bibharti // 2.24 //</l>
-</lg></p>
-
-<p>āloke te nipatati purā sā balivyākulā vā $
-<lg>
-<l>matsādṛśyaṃ virahatanu vā bhāvagamyaṃ likhantī &amp;</l>
-<l>pṛcchantī vā madhuravacanāṃ sārikāṃ pañjarasthāṃ %</l>
-<l>kaccid bhartuḥ smarasi rasike tvaṃ hi tasya priyeti // 2.25 //</l>
-</lg></p>
-
-<p>utsaṅge vā malinavasane saumya nikṣipya vīṇāṃ $
-<lg>
-<l>madgotrāṅkaṃ viracitapadaṃ geyam udgātukāmā &amp;</l>
-<l>tantrīm ārdrāṃ nayanasalilaiḥ sārayitvā kathaṃcid %</l>
-<l>bhūyo bhūyaḥ svayam api kṛtāṃ mūrcchanāṃ vismarantī // 2.26 //</l>
-</lg></p>
-
-<p>śeṣān māsān virahadivāsasthāpitasyāvadher vā $
-<lg>
-<l>vinyasyantī bhuvi gaṇanayā dehalīdattapuṣpaiḥ &amp;</l>
-<l>sambhogaṃ vā hṛdayanihitārambham āsvādayantī %</l>
-<l>prāyeṇaite ramaṇaviraheṣv aṅganānāṃ vinodāḥ // 2.27 //</l>
-</lg></p>
-
-<p>savyāpāram ahani na tathā pīḍayed viprayogaḥ $
-<lg>
-<l>śaṅke rātrau gurutaraśucaṃ nirvinodāṃ sakhīṃ te &amp;</l>
-<l>matsandeśaḥ sukhayitum alaṃ paśya sādhvīṃ niśīthe %</l>
-<l>tām unnidrām avaniśayanāṃ saudhavātāyanasthaḥ // 2.28 //</l>
-</lg></p>
-
-<p>ādhikṣāmāṃ virahaśayane saṃniṣaṇṇaikapārśvāṃ $
-<lg>
-<l>prācīmūle tanum iva kalāmātraśeṣāṃ himāṃśoḥ &amp;</l>
-<l>nītā rātriḥ kṣaṇa iva mayā sārdham icchāratair yā %</l>
-<l>tām evoṣṇair virahamahatīm aśrubhir yāpayantīm // 2.29 //</l>
-</lg></p>
-
-<p>pādān indoramṛtaśiśirāñjalamārgapraviṣṭān $
-<lg>
-<l>pūrvaprītyā gatamabhumukhaṃ saṃnivṛttaṃ tathaiva &amp;</l>
-<l>cakṣuḥ khedāt salilagurubhiḥ pakṣmabhiśchādayantīṃ %</l>
-<l>sābhre.ahnīva sthalakamalinī na prabhuddhāṃ na suptām // 2.30 //</l>
-</lg></p>
-
-<p>niḥśvāsenādharakisalayakleśinā vikṣipantīṃ $
-<lg>
-<l>śuddhasnānāt paruṣamalakaṃ nūnamāgaṇṇdalambam &amp;</l>
-<l>matsaṃbhogaḥ kathamupanamet svapnajo.apīti nidrām %</l>
-<l>ākāṅkṣantīṃ nayanasalilotpīḍaruddhāvakāśam // 2.31 //</l>
-</lg></p>
-
-<p>ādye baddhā virahadivase yā śikhā dāma hitvā $
-<lg>
-<l>śāpasyānte vigalitaśucā tāṃ mayodveṣṭanīyām &amp;</l>
-<l>sparśakliṣṭām ayamitanakhenāsakṛtsārayantīṃ %</l>
-<l>gaṇḍābhogāt kaṭhinaviṣamām ekaveṇīṃ kareṇa // 2.32 //</l>
-</lg></p>
-
-<p>sā saṃnyastābharaṇam abalā peśalaṃ dhārayantī $
-<lg>
-<l>śayyotsaṅge nihitam asakṛd duḥkhaduḥkhena gātram &amp;</l>
-<l>tvām apy asraṃ navajalamayaṃ mocayiṣyaty avaśyaṃ %</l>
-<l>prāyaḥ sarvo bhavati karuṇāvṛttir ārdrāntarātmā // 2.33 //</l>
-</lg></p>
-
-<p>jāne sakhyās tava mayi manaḥ saṃbhṛtasnehamasmād $
-<lg>
-<l>itthaṃbhūtāṃ prathamavirahe tām ahaṃ tarkayāmi &amp;</l>
-<l>vācālaṃ māṃ na khalu subhagaṃmanyabhāvaḥ karoti %</l>
-<l>pratyakṣaṃ te nikhilam acirād bhrātar uktaṃ mayā yat // 2.34 //</l>
-</lg></p>
-
-<p>ruddhāpāṅgaprasaram alakair añjanasnehaśūnyaṃ $
-<lg>
-<l>pratyādeśād api ca madhuno vismṛtabhrūvilāsam &amp;</l>
-<l>tvayy āsanne nayanam uparispandi śaṅke mṛgākṣyā %</l>
-<l>mīnakṣobhāc calakuvalayaśrītulām eṣyatīti // 2.35 //</l>
-</lg></p>
-
-<p>vāmaś cāsyāḥ kararuhapadair mucyamāno madīyair $
-<lg>
-<l>muktājālaṃ ciraparicitaṃ tyājito daivagatyā &amp;</l>
-<l>saṃbhogānte mama samucito hastasaṃvāhamānāṃ %</l>
-<l>yāsyaty ūruḥ sarasakadalīstambhagauraś calatvam // 2.36 //</l>
-</lg></p>
-
-<p>tasmin kāle jalada yadi sā labdhanidrāsukhā syād $
-<lg>
-<l>anvāsyaināṃ stanitavimukho yāmamātraṃ sahasva &amp;</l>
-<l>mā bhūd asyāḥ praṇayini mayi svapnalabdhe kathaṃcit %</l>
-<l>sadyaḥ kaṇṭhacyutabhujalatāgranthi gāḍhopagūḍham // 2.37 //</l>
-</lg></p>
-
-<p>tām utthāpya svajalakaṇikāśītalenānilena $
-<lg>
-<l>pratyāśvastāṃ samam abhinavair jālakair mālatīnām &amp;</l>
-<l>vidyudgarbhaḥ stimitanayanāṃ tvatsanāthe gavākṣe %</l>
-<l>vaktuṃ dhīraḥ stanitavacanair māninīṃ prakramethāḥ // 2.38 //</l>
-</lg></p>
-
-<p>bhartur mitraṃ priyam avidhave viddhi mām ambuvāhaṃ $
-<lg>
-<l>tatsaṃdeśair hṛdayanihitair āgataṃ tvatsamīpam &amp;</l>
-<l>yo vṛndāni tvarayati pathi śramyatāṃ proṣitānāṃ %</l>
-<l>mandrasnigdhair dhvanibhir abalāveṇimokṣotsukāni // 2.39 //</l>
-</lg></p>
-
-<p>ity ākhyāte pavanatanayaṃ maithilīvonmukhī sā $
-<lg>
-<l>tvām utkaṇṭhocchvasitahṛdayā vīkṣya sambhāvya caiva &amp;</l>
-<l>śroṣyaty asmāt param avahitā saumya sīmantinīnāṃ %</l>
-<l>kāntodantaḥ suhṛdupanataḥ saṃgamāt kiṃcid ūnaḥ // 2.40 //</l>
-</lg></p>
-
-<p>tām āyuṣman mama ca vacanād ātmanaś copakartuṃ $
-<lg>
-<l>brūyā evaṃ tava sahacaro rāmagiryāśramasthaḥ &amp;</l>
-<l>avyāpannaḥ kuśalam abale pṛcchati tvāṃ viyuktaḥ %</l>
-<l>pūrvābhāṣyaṃ sulabhavipadāṃ prāṇinām etad eva // 2.41 //</l>
-</lg></p>
-
-<p>aṅgenāṅgaṃ pratanu tanunā gāḍhataptena taptaṃ $
-<lg>
-<l>sāsreṇāśrudrutam aviratotkaṇṭham utkaṇṭhitena &amp;</l>
-<l>uṣṇocchvāsaṃ samadhikatarocchvāsinā dūravartī %</l>
-<l>saṃkalpais tair viśati vidhinā vairiṇā ruddhamārgaḥ // 2.42 //</l>
-</lg></p>
-
-<p>śabdākhyeyaṃ yadapi kila te yaḥ sakhīnāṃ purastāt $
-<lg>
-<l>karṇe lolaḥ kathayitum abhūd ānanasparśalobhāt &amp;</l>
-<l>so 'tikrāntaḥ śravaṇaviṣayaṃ locanābhyām adṛṣṭas %</l>
-<l>tvām utkaṇṭhāviracitapadaṃ manmukhenedam āha // 2.43 //</l>
-</lg></p>
-
-<p>śyāmāsv aṅgaṃ cakitahariṇīprekṣaṇe dṛṣṭipātaṃ $
-<lg>
-<l>vaktracchāyāṃ śaśini śikhināṃ barhabhāreṣu keśān &amp;</l>
-<l>utpaśyāmi pratanuṣu nadīvīciṣu bhrūvilāsān %</l>
-<l>hantaikasmin kvacid api na te caṇḍi sādṛśyam asti // 2.44 //</l>
-</lg></p>
-
-<p>tvām ālikhya praṇayakupitāṃ dhāturāgaiḥ śilāyām $
-<lg>
-<l>ātmānaṃ te caraṇapatitaṃ yāvad icchāmi kartum &amp;</l>
-<l>asrais tāvan muhur upacitair dṛṣṭir ālupyate me %</l>
-<l>krūras tasminn api na sahate saṃgamaṃ nau kṛtāntaḥ // 2.45 //</l>
-</lg></p>
-
-<p>dhārāsiktasthalasurabhiṇas tvanmukhasyāsya bāle $
-<lg>
-<l>dūrībhūtaṃ pratanum api māṃ pañcabāṇaḥ kṣiṇoti &amp;</l>
-<l>gharmānte 'smin vigaṇaya kathaṃ vāsarāṇi vrajeyur %</l>
-<l>diksaṃsaktapravitataghanavyastasūryātapāni // 2.45a //</l>
-</lg></p>
-
-<p>mām ākāśapraṇihitabhujaṃ nirdayāśleṣahetor $
-<lg>
-<l>labdhāyās te katham api mayā svapnasandarśaneṣu &amp;</l>
-<l>paśyantīnāṃ na khalu bahuśo na sthalīdevatānāṃ %</l>
-<l>muktāsthūlās tarukisalayeṣv aśruleśāḥ patanti // 2.46 //</l>
-</lg></p>
-
-<p>bhittvā sadyaḥ kisalayapuṭān devadārudrumāṇāṃ $
-<lg>
-<l>ye tatkṣīrasrutisurabhayo dakṣiṇena pravṛttāḥ &amp;</l>
-<l>āliṅgyante guṇavati mayā te tuṣārādrivātāḥ %</l>
-<l>pūrvaṃ spṛṣṭaṃ yadi kila bhaved aṅgam ebhis taveti // 2.47 //</l>
-</lg></p>
-
-<p>saṃkṣipyante kṣana iva kathaṃ dīrghayāmā triyāmā $
-<lg>
-<l>sarvāvasthāsv ahar api kathaṃ mandamandātapaṃ syāt &amp;</l>
-<l>itthaṃ cetaś caṭulanayane durlabhaprārthanaṃ me %</l>
-<l>gāḍhoṣmābhiḥ kṛtam aśaraṇaṃ tvadviyogavyathābhiḥ // 2.48 //</l>
-</lg></p>
-
-<p>nanv ātmānaṃ bahu vigaṇayann ātmanaivāvalambe $
-<lg>
-<l>tatkalyāṇi tvam api nitarāṃ mā gamaḥ kātaratvam &amp;</l>
-<l>kasyātyantaṃ sukham upanataṃ duḥkham ekāntato vā %</l>
-<l>nīcair gacchaty upari ca daśā cakranemikrameṇa // 2.49 //</l>
-</lg></p>
-
-<p>śāpānto me bhujagaśayanād utthite śārṅgapāṇau $
-<lg>
-<l>śeṣān māsān gamaya caturo locane mīlayitvā &amp;</l>
-<l>paścād āvāṃ virahaguṇitaṃ taṃ tam ātmābhilāṣaṃ %</l>
-<l>nirvekṣyāvaḥ pariṇataśaraccandrikāsu kṣapāsu // 2.50 //</l>
-</lg></p>
-
-<p>bhūyaścāha tvam api śayane kaṇṭhalagnā purā me $
-<lg>
-<l>nidrāṃ gatvā kim api rudatī sasvaraṃ viprabuddhā &amp;</l>
-<l>sāntarhāsaṃ kathitam asakṛt pṛcchataś ca tvayā me %</l>
-<l>dṛṣṭaḥ svapne kitava ramayan kām api tvaṃ mayeti // 2.51 //</l>
-</lg></p>
-
-<p>etasmān māṃ kuśalinam abhijñānadānād viditvā $
-<lg>
-<l>mā kaulīnād asitanayane mayy aviśvāsinī bhūḥ &amp;</l>
-<l>snehān āhuḥ kim api virahe dhvaṃsinas te tv abhogād %</l>
-<l>iṣṭe vastuny upacitarasāḥ premarāśībhavanti // 2.52 //</l>
-</lg></p>
-
-<p>āśvāsyaivaṃ prathamavirahodagraśokāṃ sakhīṃ te $
-<lg>
-<l>śailād āśu trinayanavṛṣotkhātakūṭān nivṛttaḥ &amp;</l>
-<l>sābhijñānaprahitakuśalais tadvacobhir mamāpi %</l>
-<l>prātaḥ kundaprasavaśithilaṃ jīvitaṃ dhārayethāḥ // 2.53 //</l>
-</lg></p>
-
-<p>kaccit saumya vyavasitam idaṃ bandhukṛtyaṃ tvayā me $
-<lg>
-<l>pratyādeśān na khalu bhavato dhīratāṃ kalpayāmi &amp;</l>
-<l>niḥśabdo 'pi pradiśasi jalaṃ yācitaś cātakebhyaḥ %</l>
-<l>pratyuktaṃ hi praṇayiṣu satām īpsitārthakriyaiva // 2.54 //</l>
-</lg></p>
-
+<div n="1"><head>pūrvameghaḥ</head>
+<lg xml:id="KalMgD.1.1">
+<l>kaścit kāntāvirahaguruṇā svādhikārāt pramattaḥ </l>
+<l>śāpenāstaṃgamitamahimā varṣabhogyeṇa bhartuḥ |</l>
+<l>yakṣaś cakre janakatanayāsnānapuṇyodakeṣu </l>
+<l>snigdhacchāyātaruṣu vasatiṃ rāmagiryāśrameṣu || 1 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.2">
+<l>tasminn adrau katicid abalāviprayuktaḥ sa kāmī </l>
+<l>nītvā māsān kanakavalayabhraṃśariktaprakoṣṭhaḥ |</l>
+<l>āṣāḍhasya prathamadivase megham āśliṣṭasānuṃ </l>
+<l>vaprakrīḍāpariṇatagajaprekṣaṇīyaṃ dadarśa || 2 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.3">
+<l>tasya sthitvā katham api puraḥ kautukādhānahetor </l>
+<l>antarbāṣpaś ciram anucaro rājarājasya dadhyau |</l>
+<l>meghāloke bhavati sukhino 'py anyathāvṛtti cetaḥ </l>
+<l>kaṇṭhāśleṣapraṇayini jane kiṃ punar dūrasaṃsthe || 3 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.4">
+<l>pratyāsanne nabhasi dayitājīvitālambanārthī </l>
+<l>jīmūtena svakuśalamayīṃ hārayiṣyan pravṛttim |</l>
+<l>sa pratyagraiḥ kuṭajakusumaiḥ kalpitārghāya tasmai </l>
+<l>prītaḥ prītipramukhavacanaṃ svāgataṃ vyājahāra || 4 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.5">
+<l>dhūmajyotiḥsalilamarutāṃ saṃnipātaḥ kva meghaḥ </l>
+<l>sandeśārthāḥ kva paṭukaraṇaiḥ prāṇibhiḥ prāpaṇīyāḥ |</l>
+<l>ity autsukyād aparigaṇayan guhyakas taṃ yayāce </l>
+<l>kāmārtā hi prakṛtikṛpaṇāś cetanācetaeṣu || 5 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.6">
+<l>jātaṃ vaṃśe bhuvanavidite puṣkarāvartakānāṃ </l>
+<l>jānāmi tvāṃ prakṛtipuruṣaṃ kāmarūpaṃ maghonaḥ |</l>
+<l>tenārthitvaṃ tvayi vidhivaśād dūrabandhur gato 'haṃ </l>
+<l>yācñā moghā varam adhiguṇe nādhame labdhakāmā || 6 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.7">
+<l>saṃtaptānāṃ tvamasi śaraṇaṃ tat payoda priyāyāḥ </l>
+<l>saṃdeśaṃ me hara dhanapatikrodhaviśleṣitasya |</l>
+<l>gantavyā te vasatir alakā nāma yakṣeśvarāṇāṃ </l>
+<l>bāhyodyānasthitaharaśiraścandrikādhautaharmyā || 7 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.8">
+<l>tvām ārūḍhaṃ pavanapadavīm udgṛhītālakāntāḥ </l>
+<l>prekṣiṣyante pathikavanitāḥ pratyayād āśvasantyaḥ |</l>
+<l>kaḥ saṃnaddhe virahavidhurāṃ tvayy upekṣeta jāyāṃ </l>
+<l>na syād anyo 'py aham iva jano yaḥ parādhīnavṛttiḥ || 8 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.9">
+<l>tvāṃ cāvaśyaṃ divasagaṇanātatparām ekapatnīm </l>
+<l>avyāpannām avihatagatir drakṣyasi bhrātṛjāyām |</l>
+<l>āśābandhaḥ kusumasadṛśaṃ prāyaśo hy aṅganānāṃ </l>
+<l>sadyaḥ pāti praṇayi hṛdayaṃ viprayoge ruṇaddhi || 9 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.10">
+<l>mandaṃ mandaṃ nudati pavanaś cānukūlo yathā tvāṃ </l>
+<l>vāmaś cāyaṃ nadati madhuraṃ cātakas te sagandhaḥ |</l>
+<l>garbhādhānakṣaṇaparicayān nūnam ābaddhamālāḥ </l>
+<l>seviṣyante nayanasubhagaṃ khe bhavantaṃ balākāḥ || 10 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.11">
+<l>kartuṃ yac ca prabhavati mahīm ucchilīndhrām avandhyāṃ </l>
+<l>tac chrutvā te śravaṇasubhagaṃ garjitaṃ mānasotkāḥ |</l>
+<l>ā kailāsād bisakisalayacchedapātheyavantaḥ </l>
+<l>saṃpatsyante nabhasi bhavato rājahaṃsāḥ sahāyāḥ || 11 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.12">
+<l>āpṛcchasva priyasakham amuṃ tuṅgam āliṅgya śailaṃ </l>
+<l>vandyaiḥ puṃsāṃ raghupatipadair aṅkitaṃ mekhalāsu |</l>
+<l>kāle kāle bhavati bhavato yasya saṃyogam etya </l>
+<l>snehavyaktiś ciravirahajaṃ muñcato bāṣpamuṣṇam || 12 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.13">
+<l>margaṃ tāvac chṛṇu kathayatas tvatprayāṇānurūpaṃ </l>
+<l>saṃdeśaṃ me tadanu jalada śroṣyasi śrotrapeyam |</l>
+<l>khinnaḥ khinnaḥ śihariṣu padaṃ nyasya gantāsi yatra </l>
+<l>kṣīṇaḥ kṣīṇaḥ parilaghu payaḥ srotasāṃ copabhujya || 13 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.14">
+<l>adreḥ śṛṅgaṃ harati pavanaḥ kiṃ svid ity unmukhībhir </l>
+<l>dṛṣṭotsāhaś cakitacakitaṃ mugdhasiddhāṅganābhiḥ |</l>
+<l>sthānād asmāt sarasaniculād utpatodaṅmukhaḥ khaṃ </l>
+<l>diṅnāgānāṃ pathi pariharan sthūlahastāvalepān || 14 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.15">
+<l>ratnacchāyāvyatikara iva prekṣyametatpurastād </l>
+<l>valmīkāgrāt prabhavati dhanuḥkhaṇḍam ākhaṇḍalasya |</l>
+<l>yena śyāmaṃ vapur atitarāṃ kāntim āpatsyate te </l>
+<l>barheṇeva sphuritarucinā gopaveṣasya viṣṇoḥ || 15 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.16">
+<l>tvayy āyantaṃ kṛṣiphalam iti bhrūvikārān abhijñaiḥ </l>
+<l>prītisnigdhairjanapadavadhūlocanaiḥ pīyamānaḥ |</l>
+<l>sadyaḥsīrotkaṣaṇasurabhi kṣetram āruhya mālaṃ </l>
+<l>kiṃcit paścād vraja laghugatir bhūya evottareṇa || 16 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.17">
+<l>tvām āsārapraśamitavanopaplavaṃ sādhu mūrdhnā </l>
+<l>vakṣyaty adhvaśramaparigataṃ sānumān āmrakūṭaḥ |</l>
+<l>na kṣudro 'pi prathamasukṛtāpekṣayā saṃśrayāya </l>
+<l>prāpte mitre bhavati vimukhaḥ kiṃ punar yas tatthoccaiḥ || 17 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.18">
+<l>channopāntaḥ pariṇataphaladyotibhiḥ kānanāmrais </l>
+<l>tvayy ārūḍhe śikharam acalaḥ snigdhaveṇīsavarṇe |</l>
+<l>nūnaṃ yāsyaty amaramithunaprekṣaṇīyām avasthāṃ </l>
+<l>madhye śyāmaḥ stana iva bhuvaḥ śeṣavistārapāṇḍuḥ || 18 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.19">
+<l>sthitvā tasmin vanacaravadhūbhuktakuñje muhūrtaṃ </l>
+<l>toyotsargadrutataragatis tatparaṃ vartma tīrṇaḥ |</l>
+<l>revāṃ drakṣyasy upalaviṣame vindhyapāde viśīrṇāṃ </l>
+<l>bhakticchedair iva viracitāṃ bhūtim aṅge gajasya || 19 ||</l>
+</lg>
+
+<del><lg xml:id="KalMgD.1.19a">
+<l>adhvaklāntaṃ pratimukhagataṃ sānumānāmrakūṭas </l>
+<l>tuṅgena tvāṃ jalada śirasā vakṣyati ślāghamānaḥ |</l>
+<l>āsāreṇa tvam api śamayes tasya naidāgham agniṃ </l>
+<l>sadbhāvārdraḥ phalati na cireṇopakāro mahatsu || 19a ||</l>
+</lg></del>
+
+<lg xml:id="KalMgD.1.20">
+<l>tasyās tiktair vanagajamadair vāsitaṃ vāntavṛṣṭir </l>
+<l>jambūkuñjapratihatarayaṃ toyam ādāya gaccheḥ |</l>
+<l>antaḥsāraṃ ghana tulayituṃ nānilaḥ śakṣyati tvāṃ </l>
+<l>riktaḥ sarvo bhavati hi laghuḥ pūrṇatā gauravāya || 20 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.21">
+<l>nīpaṃ dṛṣṭvā haritakapiśaṃ kesarair ardharūḍhair </l>
+<l>āvirbhūtaprathamamukulāḥ kandalīś cānukaccham |</l>
+<l>jagdhvāraṇyeṣv adhikasurabhiṃ gandham āghrāya corvyāḥ </l>
+<l>sāraṅgās te jalalavamucaḥ sūcayiṣyanti mārgam || 21 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.22">
+<l>ambhobindugrahaṇacaturāṃś cātakān vīkṣamāṇāḥ </l>
+<l>śreṇībhūtāḥ parigaṇanayā nirdiśanto balākāḥ |</l>
+<l>tvām āsādya stanitasamaye mānayiṣyanti siddhāḥ </l>
+<l>sotkampāni priyasahacarīsaṃbhramāliṅgitāni || 22 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.23">
+<l>utpaśyāmi drutamapi sakhe matpriyārthaṃ yiyāsoḥ </l>
+<l>kālakṣepaṃ kakubhasurabhau parvate parvete te |</l>
+<l>śuklāpāṅgaiḥ sajalanayanaiḥ svāgatīkṛtya kekāḥ </l>
+<l>pratudyātaḥ katham api bhavān gantum āśu vyavasyet || 23 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.24">
+<l>pāṇḍucchāyopavanavṛtayaḥ ketakaiḥ sūcibhinnair </l>
+<l>nīḍārambhair gṛhabalibhujām ākulagrāmacaityāḥ |</l>
+<l>tvayy āsanne pariṇataphalaśyāmajambūvanāntāḥ </l>
+<l>saṃpatsyante katipayadinasthāyihaṃsā daśārṇāḥ || 24 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.25">
+<l>teṣāṃ dikṣu prathitavidiśālakṣaṇāṃ rājadhānīṃ </l>
+<l>gatvā sadyaḥ phalam avikalaṃ kāmukatvasya labdhā |</l>
+<l>tīropāntastanitasubhagaṃ pāsyasi svādu yasmāt </l>
+<l>sabhrūbhaṅgaṃ mukham iva payo vetravatyāś calormi || 25 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.26">
+<l>nīcairākhyaṃ girim adhivases tatra viśrāmahetos </l>
+<l>tvatsamparkāt pulakitam iva prauḍhapuṣpaiḥ kadambaiḥ |</l>
+<l>yaḥ puṇyastrīratiparimalodgāribhir nāgarāṇām </l>
+<l>uddāmāni prathayati śilāveśmabhir yauvanāni || 26 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.27">
+<l>viśrāntaḥ san vraja vananadītīrajānāṃ niṣiñcann </l>
+<l>udyānānāṃ navajalakaṇair yūthikājālkāni |</l>
+<l>gaṇḍasvedāpanayanarujāklāntakarṇotpalānāṃ </l>
+<l>chāyādānāt kṣaṇaparicitaḥ puṣpalāvīmukhānām || 27 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.28">
+<l>vakraḥ panthā yadapi bhavataḥ prasthitasyottarāśāṃ </l>
+<l>saudhotsaṅgapraṇayavimukho mā sma bhūr ujjayinyāḥ |</l>
+<l>vidyuddāmasphuritacakritais tatra paurāṅganānāṃ </l>
+<l>lolāpāṅgair yadi na ramase locanair vañcito 'si || 28 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.29">
+<l>vīcikṣobhastanitavihagaśreṇikāñcīguṇāyāḥ </l>
+<l>saṃsarpantyāḥ skhalitasubhagaṃ darśitāvartanābhaḥ |</l>
+<l>nirvindhyāyāḥ pathi bhava rasābhyantaraḥ saṃnipatya </l>
+<l>strīṇām ādyaṃ praṇayavacanaṃ vibhramo hi priyeṣu || 29 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.30">
+<l>veṇībhūtapratanusalilā tām atītasya sindhuḥ </l>
+<l>pāṇḍucchāyā taṭaruhatarubhraṃśibhirjīrṇaparṇaiḥ |</l>
+<l>saubhāgyaṃ te subhaga virahāvasthayā vyañjayantī </l>
+<l>kārśyaṃ yena tyajati vidhinā sa tvayaivopapādyaḥ || 30 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.31">
+<l>prāpyāvantīn udayanakathākovidagrāmavṛddhān </l>
+<l>pūrvoddiṣṭām upasara purīṃ śrīviśālāṃ viśālām |</l>
+<l>svalpībhūte sucaritaphale svargiṇāṃ gāṃ gatānāṃ </l>
+<l>śeṣaiḥ puṇyair hṛtam iva divaḥ kāntimat khaṇḍam ekam || 31 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.32">
+<l>dīrghīkurvan paṭu madakalaṃ kūjitaṃ sārasānāṃ </l>
+<l>pratyūṣeṣu sphuṭitakamalāmodamaitrīkaṣāyaḥ |</l>
+<l>yatra strīṇāṃ harati surataglānim aṅgānukūlaḥ </l>
+<l>śiprāvātaḥ priyatama iva prārthanācāṭukāraḥ || 32 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.33">
+<l>hārāṃs tārāṃs taralaguṭikān koṭiśaḥ śaṅkaśuktīḥ </l>
+<l>śaṣpaśyāmān marakatamaṇīn unmayūkhaprarohān |</l>
+<l>dṛṣṭvā yasyāṃ vipaṇiracitān vidrumāṇāṃ ca bhaṅgān </l>
+<l>saṃlakṣyante salilanidhayas toyamātrāvaśeṣāḥ || 33 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.34">
+<l>pradyotasya priyaduhitaraṃ vatsarājo 'tra jahre </l>
+<l>haimaṃ tāladrumavanam abhūd atra tasyaiva rājñaḥ |</l>
+<l>atrodbhrāntaḥ kila nalagiriḥ stambham utpāṭya darpād </l>
+<l>ity āgantūn ramayati jano yatra bandhūn abhijñaḥ || 34 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.35">
+<l>jālodgīrṇair upacitavapuḥ keśasaṃskāradhūpair </l>
+<l>bandhuprītyā bhavanaśikhjibhir dattanṛtyopahāraḥ |</l>
+<l>harmyeṣv asyāḥ kusumasurabhiṣv adhavakhedaṃ nayethā </l>
+<l>lakṣmīṃ paśyaṃl lalitavanitāpādarāgāṅkiteṣu || 35 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.36">
+<l>bhartuḥ kaṇṭhacchavir iti gaṇaiḥ sādaraṃ vīkṣyamāṇaḥ </l>
+<l>puṇyaṃ yāyās tribhuvanaguror dhāma caṇḍīśvarasya |</l>
+<l>dhūtodyānaṃ kuvalayarajogandhibhir gandhavatyās </l>
+<l>toyakrīḍāniratayuvatisnānatiktair marudbhiḥ || 36 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.37">
+<l>apy anyasmiñ jaladhara mahākālam āsādya kāle </l>
+<l>sthātavyaṃ te nayanaviṣayaṃ yāvad atyeti bhānuḥ |</l>
+<l>kurvan sandhyāvalipaṭahatāṃ śūlinaḥ ślāghanīyām </l>
+<l>āmandrāṇāṃ phalam avikalaṃ lapsyase garjitānām || 37 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.38">
+<l>pādanyāsaiḥ kvaṇitaraśanās tatra līlāvadhūtai </l>
+<l>ratnacchāyākhacitavalibhiś cāmaraiḥ klāntahastāḥ |</l>
+<l>veśyās tvatto nakhapadasukhān prāpya varṣāgrabindūn </l>
+<l>āmokṣyante tvayi madhukaraśreṇidīrghān kaṭakṣān || 38 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.39">
+<l>paścād uccairbhujataruvanaṃ maṇḍalenābhlīnaḥ </l>
+<l>sāṃdhyaṃ tejaḥ pratinavajapāpuṣparaktaṃ dadhānaḥ |</l>
+<l>nṛttārambhe hara paśupater ārdranāgājinecchāṃ </l>
+<l>śāntodvegastimitanayanaṃ dṛṣṭabhaktir bhavānyā || 39 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.40">
+<l>gacchantīnāṃ ramāṇavasatiṃ yoṣitāṃ tatra naktaṃ </l>
+<l>ruddhāloke narapatipathe sūcibhedyais tamobhiḥ |</l>
+<l>saudāmanyā kanakanikaṣasnigdhayā darśayorvīṃ </l>
+<l>toyotsargastanitamuharo mā ca bhūrviklavāstāḥ || 40 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.41">
+<l>tāṃ kasyāṃcid bhavanavalabhau suptapārāvatāyāṃ </l>
+<l>nītvā rātriṃ ciravilasanāt khinnavidyutkalatraḥ |</l>
+<l>dṛṣṭe sūrye punarapi bhavān vāhayedadhvaśeṣaṃ </l>
+<l>mandāyante na khalu suhṛdāmabhyupatārthakṛtyāḥ || 41 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.42">
+<l>tasmin kāle nayanasaliaṃ yoṣitāṃ khaṇḍitānāṃ </l>
+<l>śāntiṃ neyaṃ praṇayibhir ato vartma bhānos tyajāśu |</l>
+<l>prāleyāstraṃ kamalavadanāt <corr>so'pi</corr> hartuṃ nalinyāḥ</l>
+<l>pratyāvṛttastvayi kararudhi syādanalpabhyasūyaḥ || 42 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.43">
+<l>gambhīrāyāḥ payasi saritaś cetasīva prasanne </l>
+<l>chāyātmāpi prakṛtisubhago lapsyate te praveśam |</l>
+<l>tasmād asyāḥ kumudaviśadāny arhasi tvaṃ na dhairyān </l>
+<l>moghīkartuṃ caṭulaśaphorodvartanaprekṣitāni || 43 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.44">
+<l>tasyāḥ kiṃcit karadhṛtam iva prāptvāīraśākhaṃ </l>
+<l>hṛtvā nīlaṃ salilavasanaṃ muktarodhonitambam |</l>
+<l>prasthānaṃ te katham api sakhe lambamānasya bhāvi </l>
+<l>jñātāsvādo vivṛtajaghanāṃ ko vihātuṃ samarthā || 44 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.45">
+<l>tvanniṣyandocchvasitavasudhāgandhasamparkaramyaḥ </l>
+<l>srotorandhradhvanitasubhagaṃ dantibhiḥ pīyamānaḥ |</l>
+<l>nīcair vāsyaty upajigamiṣor devapūrvaṃ giriṃ te </l>
+<l>śīto vāyuḥ pariṇamayitā kānanodumbarāṇām || 45 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.46">
+<l>tatra skandaṃ niyatavasatiṃ puṣpameghīkṛtātmā </l>
+<l>puṣpāsāraiḥ snapayatu bhavān vyomagaṅgājalārdraiḥ |</l>
+<l>rakṣāhetor navaśaśibhṛtā vāsavīnāṃ camūnām </l>
+<l>atyādityaṃ hutavahamukhe saṃbhṛtaṃ tad dhi teyaḥ || 46 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.47">
+<l>jyotirlekhāvalayi galitaṃ yasya barhaṃ bhavānī </l>
+<l>putrapremṇā kuvalayadalaprāpi karṇe karoti |</l>
+<l>dhautāpāṅgaṃ haraśaśirucā pāvakes taṃ mayūraṃ </l>
+<l>paścād adrigrahaṇagurubhir garjitair nartayethāḥ || 47 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.48">
+<l>ārādyainaṃ śaravaṇabhavaṃ devam ullaṅghitādhvā </l>
+<l>siddhadvandvair jalakaṇabhayād vīṇibhir muktamārgaḥ |</l>
+<l>vyālambethāḥ surabhitanayālambhajāṃ mānayiṣyan </l>
+<l>srotomūrtyā bhuvi pariṇatāṃ rantidevasya kīrtim || 48 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.49">
+<l>tvayy ādātuṃ jalam avanate śārṅgiṇo varṇacaure </l>
+<l>tasyāḥ sindhoḥ pṛthum api tanuṃ dūrabhāvāt pravāham |</l>
+<l>prekṣiṣyante gaganagatayo nūnam āvarjya dṛṣṭir </l>
+<l>ekaṃ bhuktāguṇam iva bhuvaḥ sthūlamadhyendranīlam || 49 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.50">
+<l>tām uttīrya vraja paricitabhrūlatāvibhramāṇāṃ </l>
+<l>pakṣmotkṣepād uparivilasatkṛṣṇaśāraprabhāṇām |</l>
+<l>kundakṣepānugamadhukaraśrīmuṣām ātmabimbaṃ </l>
+<l>pātrīkurvan daśapuravadhūnetrakautūhalānām || 50 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.51">
+<l>brahmāvartaṃ janapadam atha cchāyayā gāhamānaḥ </l>
+<l>kṣetraṃ kṣatrapradhanapiśunaṃ kauravaṃ tad bhajethāḥ |</l>
+<l>rājanyānāṃ śitaśaraśatair yatra gāṇḍīvadhanvā </l>
+<l>dhārāpātais tvam iva kamalāny abhyavarṣan mukhāni || 51 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.52">
+<l>hitvā hālām abhimatarasāṃ revatīlocanāṅkāṃ </l>
+<l>bandhuprītyā samaravimukho lāṅgalī yāḥ siṣeve |</l>
+<l>kṛtvā tāsām adhigamam apāṃ saumya sārasvatīnām </l>
+<l>antaḥ śuddhas tvam api bhavitā varṇamātreṇa kṛṣṇaḥ || 52 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.53">
+<l>tasmād gaccher anukanakhalaṃ śailarājāvatīrṇāṃ </l>
+<l>jāhnoḥ kanyāṃ sagaratanayasvargasopānapaṅktim |</l>
+<l>gaurīvaktrabhrukuṭiracanāṃ yā vihasyeva phenaiḥ </l>
+<l>śambhoḥ keśagrahaṇam akarod indulagnormihastā || 53 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.54">
+<l>tasyāḥ pātuṃ suragaja iva vyomni paścārdhalambī </l>
+<l>tvaṃ ced acchasphaṭikaviśadaṃ tarkayes tiryag ambhaḥ |</l>
+<l>saṃsarpantyā sapadi bhavataḥ srotasi cchāyayāsau </l>
+<l>syād asthānopagatayamunāsaṃgamevābhirāmā || 54 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.55">
+<l>āsīnānāṃ surabhitaśilaṃ nābhigandhair mṛgāṇāṃ </l>
+<l>tasyā eva prabhavam acalaṃ prāpya gauraṃ tuṣāraiḥ |</l>
+<l>vakṣyasy adhvaśramavinayena tasya śṛṅge niṣaṇṇaḥ </l>
+<l>śobhāṃ śubhrāṃ trinayanavṛṣotkhātapaṅkopameyam || 55 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.56">
+<l>taṃ ced vāyau sarati saralaskandhasaṃghaṭṭajanmā </l>
+<l>bādhetolkākṣapitacamarībālabhāro davāgniḥ |</l>
+<l>arhasy enaṃ śamayitum alaṃ vāridhārāsahasrair </l>
+<l>āpannārtipraśamanaphalāḥ saṃpado hy uttamānām || 56 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.57">
+<l>ye saṃrambhotpatanarabhasāḥ svāṅgabhaṅgāya tasmin </l>
+<l>muktādhvānaṃ sapadi śarabhā laṅghayeyur bhavantam |</l>
+<l>tān kurvīthās tumulakarakāvṛṣṭipātāvakīrṇan </l>
+<l>ke vā na syuḥ paribhavapadaṃ niṣphalārambhayatnāḥ || 57 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.58">
+<l>tatra vyaktaṃ dṛṣadi caraṇanyāsam ardhendumauleḥ </l>
+<l>śaśvat siddhair upacitabaliṃ bhaktinamraḥ parīyāḥ |</l>
+<l>yasmin dṛṣṭe karaṇavigamād ūrdhvam uddhūtapāpāḥ </l>
+<l>kalpiṣyante sthiragaṇapadaprāptaye śraddadhānāḥ || 58 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.59">
+<l>śabdāyante madhuram anilaiḥ kīcakāḥ pūryamāṇāḥ </l>
+<l>saṃraktābhis tripuravijayo gīyate kiṃnarābhiḥ |</l>
+<l>nirhrādas te muraja iva cet kandareṣu dhvaniḥ syāt </l>
+<l>saṃgītārtho nanu paśupates tatra bhāvī samagraḥ || 59 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.60">
+<l>prāleyādrer upataṭam atikramya tāṃs tān viśeṣān </l>
+<l>haṃsadvāraṃ bhṛgupatiyaśovartma yat krauñcarandhram |</l>
+<l>tenodīcīṃ diśam anusares tiryag āyāmaśobhī </l>
+<l>śyāmaḥ pādo baliniyamanābhyudyatasyeva viṣṇoḥ || 60 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.61">
+<l>gatvā cordhvaṃ daśamukhabhujocchvāsitaprasthasaṃdheḥ </l>
+<l>kailāsasya tridaśavanitādarpaṇasyātithiḥ syāḥ |</l>
+<l>śṛṅgocchrāyaiḥ kumudaviśadair yo vitatya sthitaḥ khaṃ </l>
+<l>rāśībhūtaḥ pratidinam iva tryambakasyaṭṭahāsaḥ || 61 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.62">
+<l>utpaśyāmi tvayi taṭagate snigdhabhinnāñjanābhe </l>
+<l>sadyaḥ kṛttadviradadaśanacchedagaurasya tasya |</l>
+<l>śobhām adreḥ stimitanayanaprekṣaṇīyāṃ bhavitrīm </l>
+<l>aṃsanyaste sati halabhṛto mecake vāsasīva || 62 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.63">
+<l>hitvā tasmin bhujagavalayaṃ śambhunā dattahastā </l>
+<l>krīḍāśaile yadi ca vicaret pādacāreṇa gaurī |</l>
+<l>bhaṅgībhaktyā viracitavapuḥ stambhitāntarjalaughaḥ </l>
+<l>sopānatvaṃ kuru maṇitaṭārohaṇāyāgrayāyī || 63 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.64">
+<l>tatrāvaśyaṃ valayakuliśoddhaṭṭanodgīrṇatoyaṃ </l>
+<l>neṣyanti tvāṃ surayuvatayo yantradhārāgṛhatvam |</l>
+<l>tābhyo mokṣas tava yadi sakhe gharmalabdhasya na syāt </l>
+<l>krīḍālolāḥ śravaṇaparuṣair garjitair bhāyayes tāḥ || 64 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.65">
+<l>hemāmbhojaprasavi salilaṃ mānasasyādadānaḥ </l>
+<l>kurvan kāmaṃ kṣaṇamukhapaṭaprītim airāvatasya |</l>
+<l>dhunvan kalpadrumakisalayān yaṃśukānīva vātair </l>
+<l>nānāceṣṭair jaladalalitair nirviśes taṃ nagendram || 65 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.1.66">
+<l>tasyotsaṅge praṇayina iva srastagaṅgādukūlāṃ </l>
+<l>na tvaṃ dṛṣṭvā na punar alakāṃ jñāsyase kāmacārin |</l>
+<l>yā vaḥ kāle vahati salilodgāram uccair vimānā </l>
+<l>muktājālagrathitam alakaṃ kāminīvābhravṛndam || 66 ||</l>
+</lg>
+</div>
+<div n="2"><head>uttarameghaḥ</head>
+
+<lg xml:id="KalMgD.2.1">
+<l><corr>vidyutvantaṃ</corr> lalitavanitāḥ sendracāpaṃ sacitrāḥ </l>
+<l>saṃgītāya prahatamurajāḥ snigdhagambhīraghoṣam |</l>
+<l>antastoyaṃ maṇimayabhuvas tuṅgam abhraṃlihāgrāḥ </l>
+<l>prāsādās tvāṃ tulayitum alaṃ yatra tais tair viśeṣaiḥ || 1 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.2">
+<l>haste līlākamalam alake bālakundānuviddhaṃ </l>
+<l>nītā lodhraprasavarajasā pāṇḍutām ānane śrīḥ |</l>
+<l>cūḍāpāśe navakuravakaṃ cāru karṇe śirīṣaṃ </l>
+<l>sīmante ca tvadupagamajaṃ yatra nīpaṃ vadhūnām || 2 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.3">
+<l>yatronmattabhramaramukharāḥ pādapā nityapuṣpā </l>
+<l>haṃsaśreṇīracitaraśanā nityapadmā nalinyaḥ |</l>
+<l>kekotkaṇṭhā bhuvanaśikhino nityabhāsvatkalāpā </l>
+<l>nityajyotsnāḥ prahitatamovṛttiramyāḥ pradoṣāḥ || 3 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.4">
+<l>ānandotthaṃ nayanasalilamyatra nānyair nimittair </l>
+<l>nānyas tāpaṃ kusumaśarajād iṣṭasaṃyogasādhyāt |</l>
+<l>nāpy anyasmāt praṇayakalahād viprayogopapattir </l>
+<l>vitteśānāṃ na ca khalu vayo yauvanād anyad asti || 4 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.5">
+<l>yasyāṃ yakṣāḥ sitamaṇimayāny etya harmyasthalāni </l>
+<l>jyotiśchāyākusumaracitāny uttamastrīsahāyāḥ |</l>
+<l>āsevante madhu ratiphalaṃ kalpavṛkṣaprasūtaṃ </l>
+<l>tvadgambhīradhvaniṣu śanakaiḥ puṣkareṣv āhateṣu || 5 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.6">
+<l>mandākinyāḥ salilaśiśiraiḥ sevyamānā marudbhir </l>
+<l>mandārāṇām anutaṭaruhāṃ chāyayā vāritoṣṇāḥ |</l>
+<l>anveṣṭavyaiḥ kanakasikatāmuṣṭinikṣepagūḍhaiḥ </l>
+<l>saṃkrīḍante maṇibhiramaraprārthitayā yatra kanyāḥ || 6 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.7">
+<l>nīvībandhocchvāsitaśithilaṃ yatra bimbādharāṇāṃ </l>
+<l>kṣaumaṃ rāgādanibhṛtakareṣv ākṣipatsu priyeṣu |</l>
+<l>arcistuṅgān abhimukham api prāpya ratnapradīpān </l>
+<l>hrīmūḍhānāṃ bhavati viphalapreraṇā cūrṇamuṣṭiḥ || 7 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.8">
+<l>netrā nītāḥ satatagatinā yadvimānāgrabhūmīr </l>
+<l>ālekhyānāṃ salilakaṇikādoṣam utpādya sadyaḥ |</l>
+<l>śaṅkāspṛṣṭā iva jalamucas tvādṛśā jālamārgair </l>
+<l>dhūmodgārānukṛtinipuṇā jarjarā niṣpatanti || 8 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.9">
+<l>yatra strīṇāṃ priyatamabhujocchvāsitāliṅgitānām </l>
+<l>aṅgaglāniṃ suratajanitāṃ tantujālāvalambāḥ |</l>
+<l>tvatsaṃrodhāpagamaviśadaś candrapādair niśīthe </l>
+<l>vyālumpanti sphuṭajalalavasyandinaś candrakāntāḥ || 9 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.10">
+<l>akṣayyāntarbhavananidhayaḥ pratyahaṃ raktakaṇṭhair </l>
+<l>udgāyadbhir dhanapatiyaśaḥ kiṃnarair yatra sārdham |</l>
+<l>vaibhrājākhyaṃ vibudhavanitāvāramukhyasahāyā </l>
+<l>baddhālāpā bahirupavanaṃ kāmino nirviśanti || 10 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.11">
+<l>gatyutkampād alakapatitair yatra mandārapuṣpaiḥ </l>
+<l>putracchedaiḥ kanakakamalaiḥ karṇavisraṃśibhiś ca |</l>
+<l>muktājālaiḥ stanaparisaracchinnasūtraiś ca hārair </l>
+<l>naiśo mārgaḥ savitur udaye sūcyate kāminīnām || 11 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.12">
+<l>vāsaś citraṃ madhu nayanayor vibhramādeśadakṣaṃ </l>
+<l>puṣpodbhedaṃ saha kisalayair bhūṣaṇānāṃ vikalpam |</l>
+<l>lākṣārāgaṃ caraṇakamalanyāsayogyaṃ ca yasyām </l>
+<l>ekaḥ sūte sakalam abalāmaṇḍanaṃ kalpavṛkṣaḥ || 12 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.13">
+<l>patraśyāmā dinakarahayaspardhino yatra vāhāḥ </l>
+<l>śailodagrās tvam iva kariṇo vṛṣṭimantaḥ prabhedāt |</l>
+<l>yodhāgraṇyaḥ pratidaśamukhaṃ saṃyuge tasthivāṃsaḥ </l>
+<l>pratyādiṣṭābharaṇarucayaś candrahāsavraṇāṅkaiḥ || 13 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.14">
+<l>matvā devaṃ dhanapatisakhaṃ yatra sākṣād vasantaṃ </l>
+<l>prāyaś cāpaṃ na vahati bhayān manmathaḥ ṣaṭpadajyam |</l>
+<l>sabhrūbhaṅgaprahitanayanaiḥ kāmilakṣyeṣv amoghais </l>
+<l>tasyārambhaś caturavanitāvibhramair eva siddhaḥ || 14 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.15">
+<l>tatrāgāraṃ dhanapatigṛhān uttareṇāsmadīyaṃ </l>
+<l>dūrāl lakṣyaṃ surapatidhanuścāruṇā toraṇena |</l>
+<l>yasyopānte kṛtakatanayaḥ kāntayā vardhito me </l>
+<l>hastaprāpyastavakanamito bālamandāravṛkṣaḥ || 15 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.16">
+<l>vāpī cāsmin marakataśilābaddhasopānamārgā </l>
+<l>haimaiśchannā vikacakamalaiḥ snigdhavaidūryanālaiḥ |</l>
+<l>yasyās toye kṛtavasatayo mānasaṃ saṃnikṛṣṭaṃ </l>
+<l>nādhyāsyanti vyapagataśucas tvām api prekṣya haṃsāḥ || 16 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.17">
+<l>tasyās tīre racitaśikharaḥ peśalair indranīlaiḥ </l>
+<l>krīḍāśailaḥ kanakakadalīveṣṭanaprekṣaṇīyaḥ |</l>
+<l>madgehinyāḥ priya iti sakhe cetasā kātareṇa </l>
+<l>prekṣyopāntasphuritataḍitaṃ tvāṃ tam eva smarāmi || 17 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.18">
+<l>raktāśokaś calakisalayaḥ kesaraś cātra kāntaḥ </l>
+<l>pratyāsannau kuruvakavṛter mādhavīmaṇḍapasya |</l>
+<l>ekaḥ sakhyās tava saha mayā vāmapādābhilāṣī </l>
+<l>kāṅkṣaty anyo vadanamadirāṃ dohadacchadmanāsyāḥ || 18 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.19">
+<l>tanmadhye ca sphaṭikaphalakā kāñcanī vāsayaṣṭir </l>
+<l>mūle baddhā maṇibhir anatiprauḍhavaṃśaprakāśaiḥ |</l>
+<l>tālaiḥ śiñjāvalayasubhagair nartitaḥ kāntayā me </l>
+<l>yām adhyāste divasavigame nīlakaṇṭhaḥ suhṛd vaḥ || 19 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.20">
+<l>ebhiḥ sādho hṛdayanihitair lakṣaṇair lakṣayethā </l>
+<l>dvāropānte likhitavapuṣau śaṅkhapadmau ca dṛṣṭvā |</l>
+<l>kṣāmacchāyāṃ bhavanam adhunā madviyogena nūnaṃ </l>
+<l>sūryāpāye na khalu kamalaṃ puṣyati svāmabhikhyām || 20 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.21">
+<l>gatvā sadyaḥ kalabhatanutāṃ śīghrasaṃpātahetoḥ </l>
+<l>krīḍāśaile prathamakathite ramyasānau niṣaṇṇaḥ |</l>
+<l>arhasy antarbhavanapatitāṃ kartum alpālpabhāsaṃ </l>
+<l>khadyotālīvilasitanibhāṃ vidyudunmeṣadṛṣṭim || 21 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.22">
+<l>tanvī śyāmā śikharīdaśanā pakvabimbādharauṣṭhī </l>
+<l>madhye kṣāmā cakitahariṇīprekṣaṇā nimnanābhiḥ |</l>
+<l>śroṇībhārād alasagamanā stokanamrā stanābhyāṃ </l>
+<l>yā tatra syād yuvatīviṣaye sṛṣṭir ādyaiva dhātuḥ || 22 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.23">
+<l>tāṃ jānīthāḥ parimitakathāṃ jīvitaṃ me dvitīyaṃ </l>
+<l>dūrībhūte mayi sahacare cakravākīm ivaikām |</l>
+<l>gāḍhotkaṇṭhāṃ guruṣu divaseṣv eṣu gacchatsu bālāṃ </l>
+<l>jātāṃ manye śiśiramathitāṃ padminīṃ vānyarūpām || 23 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.24">
+<l>nūnaṃ tasyāḥ prabalaruditocchūnanetraṃ priyāyā </l>
+<l>niḥśvāsānām aśiśiratayā bhinnavarṇādharoṣṭham |</l>
+<l>hastanyastaṃ mukham asakalavyakti lambālakatvād </l>
+<l>indor dainyaṃ tvadanusaraṇakliṣṭakānter bibharti || 24 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.25">
+<l>āloke te nipatati purā sā balivyākulā vā </l>
+<l>matsādṛśyaṃ virahatanu vā bhāvagamyaṃ likhantī |</l>
+<l>pṛcchantī vā madhuravacanāṃ sārikāṃ pañjarasthāṃ </l>
+<l>kaccid bhartuḥ smarasi rasike tvaṃ hi tasya priyeti || 25 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.26">
+<l>utsaṅge vā malinavasane saumya nikṣipya vīṇāṃ </l>
+<l>madgotrāṅkaṃ viracitapadaṃ geyam udgātukāmā |</l>
+<l>tantrīm ārdrāṃ nayanasalilaiḥ sārayitvā kathaṃcid </l>
+<l>bhūyo bhūyaḥ svayam api kṛtāṃ mūrcchanāṃ vismarantī || 26 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.27">
+<l>śeṣān māsān virahadivāsasthāpitasyāvadher vā </l>
+<l>vinyasyantī bhuvi gaṇanayā dehalīdattapuṣpaiḥ |</l>
+<l>sambhogaṃ vā hṛdayanihitārambham āsvādayantī </l>
+<l>prāyeṇaite ramaṇaviraheṣv aṅganānāṃ vinodāḥ || 27 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.28">
+<l>savyāpāram ahani na tathā pīḍayed viprayogaḥ </l>
+<l>śaṅke rātrau gurutaraśucaṃ nirvinodāṃ sakhīṃ te |</l>
+<l>matsandeśaḥ sukhayitum alaṃ paśya sādhvīṃ niśīthe </l>
+<l>tām unnidrām avaniśayanāṃ saudhavātāyanasthaḥ || 28 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.29">
+<l>ādhikṣāmāṃ virahaśayane saṃniṣaṇṇaikapārśvāṃ </l>
+<l>prācīmūle tanum iva kalāmātraśeṣāṃ himāṃśoḥ |</l>
+<l>nītā rātriḥ kṣaṇa iva mayā sārdham icchāratair yā </l>
+<l>tām evoṣṇair virahamahatīm aśrubhir yāpayantīm || 29 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.30">
+<l>pādān indoramṛtaśiśirāñjalamārgapraviṣṭān </l>
+<l>pūrvaprītyā gatamabhumukhaṃ saṃnivṛttaṃ tathaiva |</l>
+<l>cakṣuḥ khedāt salilagurubhiḥ pakṣmabhiśchādayantīṃ </l>
+<l><corr>sābhre'hnīva</corr> sthalakamalinī na prabhuddhāṃ na suptām || 30 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.31">
+<l>niḥśvāsenādharakisalayakleśinā vikṣipantīṃ </l>
+<l>śuddhasnānāt paruṣamalakaṃ nūnamāgaṇṇdalambam |</l>
+<l>matsaṃbhogaḥ kathamupanamet <corr>svapnajo'apīti</corr> nidrām </l>
+<l>ākāṅkṣantīṃ nayanasalilotpīḍaruddhāvakāśam || 31 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.32">
+<l>ādye baddhā virahadivase yā śikhā dāma hitvā </l>
+<l>śāpasyānte vigalitaśucā tāṃ mayodveṣṭanīyām |</l>
+<l>sparśakliṣṭām ayamitanakhenāsakṛtsārayantīṃ </l>
+<l>gaṇḍābhogāt kaṭhinaviṣamām ekaveṇīṃ kareṇa || 32 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.33">
+<l>sā saṃnyastābharaṇam abalā peśalaṃ dhārayantī </l>
+<l>śayyotsaṅge nihitam asakṛd duḥkhaduḥkhena gātram |</l>
+<l>tvām apy asraṃ navajalamayaṃ mocayiṣyaty avaśyaṃ </l>
+<l>prāyaḥ sarvo bhavati karuṇāvṛttir ārdrāntarātmā || 33 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.34">
+<l>jāne sakhyās tava mayi manaḥ saṃbhṛtasnehamasmād </l>
+<l>itthaṃbhūtāṃ prathamavirahe tām ahaṃ tarkayāmi |</l>
+<l>vācālaṃ māṃ na khalu subhagaṃmanyabhāvaḥ karoti </l>
+<l>pratyakṣaṃ te nikhilam acirād bhrātar uktaṃ mayā yat || 34 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.35">
+<l>ruddhāpāṅgaprasaram alakair añjanasnehaśūnyaṃ </l>
+<l>pratyādeśād api ca madhuno vismṛtabhrūvilāsam |</l>
+<l>tvayy āsanne nayanam uparispandi śaṅke mṛgākṣyā </l>
+<l>mīnakṣobhāc calakuvalayaśrītulām eṣyatīti || 35 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.36">
+<l>vāmaś cāsyāḥ kararuhapadair mucyamāno madīyair </l>
+<l>muktājālaṃ ciraparicitaṃ tyājito daivagatyā |</l>
+<l>saṃbhogānte mama samucito hastasaṃvāhamānāṃ </l>
+<l>yāsyaty ūruḥ sarasakadalīstambhagauraś calatvam || 36 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.37">
+<l>tasmin kāle jalada yadi sā labdhanidrāsukhā syād </l>
+<l>anvāsyaināṃ stanitavimukho yāmamātraṃ sahasva |</l>
+<l>mā bhūd asyāḥ praṇayini mayi svapnalabdhe kathaṃcit </l>
+<l>sadyaḥ kaṇṭhacyutabhujalatāgranthi gāḍhopagūḍham || 37 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.38">
+<l>tām utthāpya svajalakaṇikāśītalenānilena </l>
+<l>pratyāśvastāṃ samam abhinavair jālakair mālatīnām |</l>
+<l>vidyudgarbhaḥ stimitanayanāṃ tvatsanāthe gavākṣe </l>
+<l>vaktuṃ dhīraḥ stanitavacanair māninīṃ prakramethāḥ || 38 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.39">
+<l>bhartur mitraṃ priyam avidhave viddhi mām ambuvāhaṃ </l>
+<l>tatsaṃdeśair hṛdayanihitair āgataṃ tvatsamīpam |</l>
+<l>yo vṛndāni tvarayati pathi śramyatāṃ proṣitānāṃ </l>
+<l>mandrasnigdhair dhvanibhir abalāveṇimokṣotsukāni || 39 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.40">
+<l>ity ākhyāte pavanatanayaṃ maithilīvonmukhī sā </l>
+<l>tvām utkaṇṭhocchvasitahṛdayā vīkṣya sambhāvya caiva |</l>
+<l>śroṣyaty asmāt param avahitā saumya sīmantinīnāṃ </l>
+<l>kāntodantaḥ suhṛdupanataḥ saṃgamāt kiṃcid ūnaḥ || 40 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.41">
+<l>tām āyuṣman mama ca vacanād ātmanaś copakartuṃ </l>
+<l>brūyā evaṃ tava sahacaro rāmagiryāśramasthaḥ |</l>
+<l>avyāpannaḥ kuśalam abale pṛcchati tvāṃ viyuktaḥ </l>
+<l>pūrvābhāṣyaṃ sulabhavipadāṃ prāṇinām etad eva || 41 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.42">
+<l>aṅgenāṅgaṃ pratanu tanunā gāḍhataptena taptaṃ </l>
+<l>sāsreṇāśrudrutam aviratotkaṇṭham utkaṇṭhitena |</l>
+<l>uṣṇocchvāsaṃ samadhikatarocchvāsinā dūravartī </l>
+<l>saṃkalpais tair viśati vidhinā vairiṇā ruddhamārgaḥ || 42 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.43">
+<l>śabdākhyeyaṃ yadapi kila te yaḥ sakhīnāṃ purastāt </l>
+<l>karṇe lolaḥ kathayitum abhūd ānanasparśalobhāt |</l>
+<l>so 'tikrāntaḥ śravaṇaviṣayaṃ locanābhyām adṛṣṭas </l>
+<l>tvām utkaṇṭhāviracitapadaṃ manmukhenedam āha || 43 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.44">
+<l>śyāmāsv aṅgaṃ cakitahariṇīprekṣaṇe dṛṣṭipātaṃ </l>
+<l>vaktracchāyāṃ śaśini śikhināṃ barhabhāreṣu keśān |</l>
+<l>utpaśyāmi pratanuṣu nadīvīciṣu bhrūvilāsān </l>
+<l>hantaikasmin kvacid api na te caṇḍi sādṛśyam asti || 44 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.45">
+<l>tvām ālikhya praṇayakupitāṃ dhāturāgaiḥ śilāyām </l>
+<l>ātmānaṃ te caraṇapatitaṃ yāvad icchāmi kartum |</l>
+<l>asrais tāvan muhur upacitair dṛṣṭir ālupyate me </l>
+<l>krūras tasminn api na sahate saṃgamaṃ nau kṛtāntaḥ || 45 ||</l>
+</lg>
+
+<del><lg xml:id="KalMgD.2.45a">
+<l>dhārāsiktasthalasurabhiṇas tvanmukhasyāsya bāle </l>
+<l>dūrībhūtaṃ pratanum api māṃ pañcabāṇaḥ kṣiṇoti |</l>
+<l>gharmānte 'smin vigaṇaya kathaṃ vāsarāṇi vrajeyur </l>
+<l>diksaṃsaktapravitataghanavyastasūryātapāni || 45a ||</l>
+</lg></del>
+
+<lg xml:id="KalMgD.2.46">
+<l>mām ākāśapraṇihitabhujaṃ nirdayāśleṣahetor </l>
+<l>labdhāyās te katham api mayā svapnasandarśaneṣu |</l>
+<l>paśyantīnāṃ na khalu bahuśo na sthalīdevatānāṃ </l>
+<l>muktāsthūlās tarukisalayeṣv aśruleśāḥ patanti || 46 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.47">
+<l>bhittvā sadyaḥ kisalayapuṭān devadārudrumāṇāṃ </l>
+<l>ye tatkṣīrasrutisurabhayo dakṣiṇena pravṛttāḥ |</l>
+<l>āliṅgyante guṇavati mayā te tuṣārādrivātāḥ </l>
+<l>pūrvaṃ spṛṣṭaṃ yadi kila bhaved aṅgam ebhis taveti || 47 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.48">
+<l>saṃkṣipyante kṣana iva kathaṃ dīrghayāmā triyāmā </l>
+<l>sarvāvasthāsv ahar api kathaṃ mandamandātapaṃ syāt |</l>
+<l>itthaṃ cetaś caṭulanayane durlabhaprārthanaṃ me </l>
+<l>gāḍhoṣmābhiḥ kṛtam aśaraṇaṃ tvadviyogavyathābhiḥ || 48 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.49">
+<l>nanv ātmānaṃ bahu vigaṇayann ātmanaivāvalambe </l>
+<l>tatkalyāṇi tvam api nitarāṃ mā gamaḥ kātaratvam |</l>
+<l>kasyātyantaṃ sukham upanataṃ duḥkham ekāntato vā </l>
+<l>nīcair gacchaty upari ca daśā cakranemikrameṇa || 49 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.50">
+<l>śāpānto me bhujagaśayanād utthite śārṅgapāṇau </l>
+<l>śeṣān māsān gamaya caturo locane mīlayitvā |</l>
+<l>paścād āvāṃ virahaguṇitaṃ taṃ tam ātmābhilāṣaṃ </l>
+<l>nirvekṣyāvaḥ pariṇataśaraccandrikāsu kṣapāsu || 50 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.51">
+<l>bhūyaścāha tvam api śayane kaṇṭhalagnā purā me </l>
+<l>nidrāṃ gatvā kim api rudatī sasvaraṃ viprabuddhā |</l>
+<l>sāntarhāsaṃ kathitam asakṛt pṛcchataś ca tvayā me </l>
+<l>dṛṣṭaḥ svapne kitava ramayan kām api tvaṃ mayeti || 51 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.52">
+<l>etasmān māṃ kuśalinam abhijñānadānād viditvā </l>
+<l>mā kaulīnād asitanayane mayy aviśvāsinī bhūḥ |</l>
+<l>snehān āhuḥ kim api virahe dhvaṃsinas te tv abhogād </l>
+<l>iṣṭe vastuny upacitarasāḥ premarāśībhavanti || 52 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.53">
+<l>āśvāsyaivaṃ prathamavirahodagraśokāṃ sakhīṃ te </l>
+<l>śailād āśu trinayanavṛṣotkhātakūṭān nivṛttaḥ |</l>
+<l>sābhijñānaprahitakuśalais tadvacobhir mamāpi </l>
+<l>prātaḥ kundaprasavaśithilaṃ jīvitaṃ dhārayethāḥ || 53 ||</l>
+</lg>
+
+<lg xml:id="KalMgD.2.54">
+<l>kaccit saumya vyavasitam idaṃ bandhukṛtyaṃ tvayā me </l>
+<l>pratyādeśān na khalu bhavato dhīratāṃ kalpayāmi |</l>
+<l>niḥśabdo 'pi pradiśasi jalaṃ yācitaś cātakebhyaḥ </l>
+<l>pratyuktaṃ hi praṇayiṣu satām īpsitārthakriyaiva || 54 ||</l>
+</lg>
+</div>
   </body>
 </text>
 </TEI>


### PR DESCRIPTION
Normalize text and add divisions to meghadutam file (Kale edition)

Cleans TEI XML file(Kale edition. Filename: sa_kAlidAsa-meghadUta-edkale.xml). Following chagnes are made:

1. Original file didn't have any sections in it. Two <div> blocks were added(one for pūrvamegha and one for uttaramegha).
2. pādās of verses were not structured correctly. First line pāda of all verses was wrapped in <p> tags and rest were wrapped in <lg>. This has been corrected.
3. <head> blocks are added for each <div> (one for pūrvamegha and one for uttaramegha).
4. Following typos were corrected:
    - Verse 1.43 : `so.api` to `so'pi`
    - `vidhunvantaṃ` to `vidyutvantaṃ`
    - `sābhhre.hnīva` to `sābhre'hnīva`
    - `svapnajo.apīti` to `svapnajo'pīti` 
