### PR TITLE
Fix ko.api -> ko'pi etc.

### DIFF
--- a/1_sanskr/tei/sa_rUpagosvAmin-haMsadUta.xml
+++ b/1_sanskr/tei/sa_rUpagosvAmin-haMsadUta.xml
@@ -316,7 +316,7 @@
 <l>dukūlaṃ bibhrāṇo dalitaharitāladyutibharaṃ</l>
 <l>javāpuṣpaśreṇīrucirucirapādāmbujatalaḥ |</l>
 <l>tamālaśyāmāṅgo davahasitalīlāñcitamukhaḥ</l>
-<l>parānandābhogaḥ sphuratu hṛdi me ko.api puruṣaḥ || 1 ||</l>
+<l>parānandābhogaḥ sphuratu hṛdi me ko'pi puruṣaḥ || 1 ||</l>
 </lg>
 
 <lg xml:id="HamDu.2">
@@ -364,14 +364,14 @@
 <lg xml:id="HamDu.8">
 <l>amarṣāt premerṣyāṃ sapadi dadhatī kaṃsamathane</l>
 <l>pravṛttā haṃsāya svamabhilaṣitaṃ śaṃsitumasau |</l>
-<l>na tasyā doṣo.ayaṃ yadiha vihagaṃ prārthitavatī</l>
+<l>na tasyā doṣo'yaṃ yadiha vihagaṃ prārthitavatī</l>
 <l>na kasmin viśrambhaṃ diśati haribhaktipraṇayitā || 8 ||</l>
 </lg>
 
 <lg xml:id="HamDu.9">
 <l>pavitreṣu prāyo viracayasi toyeṣu vasatiṃ</l>
 <l>pramodaṃ nālīke vahasi viśadātmā svayamasi |</l>
-<l>tato.ahaṃ duḥkhārtā śaraṇamabalā tvāṃ gatavatī</l>
+<l>tato'haṃ duḥkhārtā śaraṇamabalā tvāṃ gatavatī</l>
 <l>na yācñā satpakṣe vrajati hi kadācidviphalatām || 9 ||</l>
 </lg>
 
@@ -676,7 +676,7 @@
 
 <lg xml:id="HamDu.53">
 <l>na nirvaktuṃ dāmodarapadakaniṣṭhāṅgulinakha-</l>
-<l>dyutīnāṃ lāvaṇyaṃ bhavati caturāsyo.api caturaḥ |</l>
+<l>dyutīnāṃ lāvaṇyaṃ bhavati caturāsyo'pi caturaḥ |</l>
 <l>tathāpi strīprajñāsulabhataralatvādahamasau</l>
 <l>pravṛttā tanmūrtistavaratimahāsāhasavaśe || 53 ||</l>
 </lg>
@@ -719,7 +719,7 @@
 <lg xml:id="HamDu.59">
 <l>urau yasya sphāraṃ sphurati vanamālāvalayitaṃ</l>
 <l>vitanvānaṃ tanvījanamanasi sadyo manasijam |</l>
-<l>marīcībhiryasmin ravinivahatulyo.api vahate</l>
+<l>marīcībhiryasmin ravinivahatulyo'pi vahate</l>
 <l>sadā khadyotābhāṃ bhuvanamadhuraḥ kaustubhamaṇiḥ || 59 ||</l>
 </lg>
 
@@ -741,7 +741,7 @@
 <l>kimebhirvyāhāraiḥ kalaya kathayāmi sphuṭamahaṃ</l>
 <l>sakhe niḥsandehaṃ paricayapadaṃ kevalamidam |</l>
 <l>parānando yasmin nayanapadavībhrāji bhavitā</l>
-<l>tvayā vijñātavyā madhurarava so.ayaṃ madhuripuḥ || 62 ||</l>
+<l>tvayā vijñātavyā madhurarava so'yaṃ madhuripuḥ || 62 ||</l>
 </lg>
 
 <lg xml:id="HamDu.63">
@@ -780,7 +780,7 @@
 </lg>
 
 <lg xml:id="HamDu.68">
-<l>prasūto devakyā madhumathana yaḥ ko.api puruṣaḥ</l>
+<l>prasūto devakyā madhumathana yaḥ ko'pi puruṣaḥ</l>
 <l>sa yāto gopālābhyudayaparamānandavasatim |</l>
 <l>dhṛto yo gāndhinyā kaṭhinajaṭhare samprati tataḥ</l>
 <l>samantādevāstaṃ śiva śiva gatā gokulakathā || 68 ||</l>
@@ -795,13 +795,13 @@
 
 <lg xml:id="HamDu.70">
 <l>tvayā nāgantavyaṃ kathamapi hare goṣṭhamadhunā</l>
-<l>latā śreṇī vṛndāvanabhuvi yato.abhūdviṣamayī |</l>
+<l>latā śreṇī vṛndāvanabhuvi yato'bhūdviṣamayī |</l>
 <l>prasūnānāṃ gandhaṃ madhumathana tadā vātanihitaṃ</l>
 <l>bhajan sadyo mūrcchāṃ vahati nivaho gopasudṛśām || 70 ||</l>
 </lg>
 
 <lg xml:id="HamDu.71">
-<l>kathaṃ saṅgo.asmābhiḥ saha samucitaḥ samprati hare-</l>
+<l>kathaṃ saṅgo'smābhiḥ saha samucitaḥ samprati hare-</l>
 <l>rayaṃ grāmyā nāryastvamasi nṛpakanyārcitapadaḥ |</l>
 <l>gataḥ kālo yasmin paśuparamaṇīsaṅgamakṛte</l>
 <l>bhavān vyagrastasthau tamasi gṛhavāṭiviṭapini || 71 ||</l>
@@ -817,7 +817,7 @@
 <lg xml:id="HamDu.73">
 <l>ayaṃ pūrvo raṅgaḥ kila paricito yasya tarasā</l>
 <l>rasādākhyātavyaṃ parikalaya tan nāṭakamidam |</l>
-<l>mayā praṣṭavyo.asi prathamamiti vṛndāvanapate</l>
+<l>mayā praṣṭavyo'si prathamamiti vṛndāvanapate</l>
 <l>kimāhā rādheti smarasi hatakaṃ varṇayugalam || 73 ||</l>
 </lg>
 
@@ -990,7 +990,7 @@
 </lg>
 
 <lg xml:id="HamDu.98">
-<l>abhūt ko.api premā mayi murariporyaḥ sakhi purā</l>
+<l>abhūt ko'pi premā mayi murariporyaḥ sakhi purā</l>
 <l>parāṃ karmāpekṣāmapi tadavalambān na gaṇayet |</l>
 <l>tathedānīṃ hā dhik samajani taṭasthaḥ sphuṭamahaṃ</l>
 <l>bhaje lajjāṃ yena kṣaṇamapi punarjīvitumapi || 98 ||</l>
@@ -1074,7 +1074,7 @@
 </lg>
 
 <lg xml:id="HamDu.110">
-<l>tato.ahaṃ dhammille sthagitamuralīkā sakhi śanai-</l>
+<l>tato'haṃ dhammille sthagitamuralīkā sakhi śanai-</l>
 <l>ralīkāmarṣeṇa bhramadaviralabhrūrudacalam |</l>
 <l>kacākṛṣṭikrīḍākramaparicite cauryacarite</l>
 <l>harirlabdhopādhiḥ prasabhamanayan māṃ giridarīm || 110 ||</l>
@@ -1089,7 +1089,7 @@
 
 <lg xml:id="HamDu.112">
 <l>atīteyaṃ vārtā viramatu puraḥ paśya sarale</l>
-<l>vayasyaste so.ayaṃ smitamadhurimonmṛṣṭavadanaḥ |</l>
+<l>vayasyaste so'yaṃ smitamadhurimonmṛṣṭavadanaḥ |</l>
 <l>bhujastambhollāsādabhimataparīrambharabhasaḥ</l>
 <l>smarakrīḍāsindhuḥ kṣipati mayi bandhukakusumam || 112 ||</l>
 </lg>
@@ -1180,7 +1180,7 @@
 
 <lg xml:id="HamDu.125">
 <l>navīnastvaṃ kambo paśuparamaṇībhiḥ paricayaṃ</l>
-<l>na dhatse rādhāyāḥ guṇagarimagandho.api na kṛtī |</l>
+<l>na dhatse rādhāyāḥ guṇagarimagandho'pi na kṛtī |</l>
 <l>tathāpi tvāṃ yāce hṛdayanihitaṃ dohadamahaṃ</l>
 <l>vahante hi klānte praṇayamavadātaprakṛtayaḥ || 125 ||</l>
 </lg>
@@ -1249,7 +1249,7 @@
 </lg>
 
 <lg xml:id="HamDu.135">
-<l>prasannaḥ kālo.ayaṃ punarudayituṃ rāsabhajanai-</l>
+<l>prasannaḥ kālo'yaṃ punarudayituṃ rāsabhajanai-</l>
 <l>rvilāsinn adyāpi sphuṭamanaparādhā vayamapi |</l>
 <l>vitanvānaḥ kāntiṃ vapuṣi śaradākāśavalitāṃ</l>
 <l>kṛto na tvaṃ sīradhvaja bhajasi vṛndāvanamidam || 135 ||</l>
@@ -1292,14 +1292,14 @@
 <lg xml:id="HamDu.141">
 <l>prapannaḥ premāṇaṃ prabhavati sadā bhāgavatabhāk</l>
 <l>parācīno janmāvadhibhavarasādbhaktimadhuraḥ |</l>
-<l>ciraṃ ko.api śrīmān jayati viditaḥ śākaratayā</l>
+<l>ciraṃ ko'pi śrīmān jayati viditaḥ śākaratayā</l>
 <l>dhurīṇo dhīrāṇāmadhidharaṇi vaiyāsakiriva || 141 ||</l>
 </lg>
 
 <lg xml:id="HamDu.142">
 <l>rasānāmādhārairaparicitadoṣaḥ sahṛdayai-</l>
 <l>rmurārāteḥ krīḍāniviḍaghaṭanārūpamahitaḥ |</l>
-<l>prabandho.ayaṃ bandhorakhilajagatāṃ tasya sarasāṃ</l>
+<l>prabandho'yaṃ bandhorakhilajagatāṃ tasya sarasāṃ</l>
 <l>prabhorantaḥ sāndrāṃ pramadalaharīṃ pallavayatu || 142 ||</l>
 </lg>
 

--- a/1_sanskr/tei/sa_rUpagosvAmin-haMsadUta.xml
+++ b/1_sanskr/tei/sa_rUpagosvAmin-haMsadUta.xml
@@ -669,7 +669,7 @@
 
 <lg xml:id="HamDu.52">
 <l>vihaṅgendro yugmīkṛtakarasarojo bhuvi puraḥ</l>
-<l>kṛtāsaṅgo bhāvī prajavini nirdeśe.arpitamanāḥ |</l>
+<l>kṛtāsaṅgo bhāvī prajavini nirdeśe'rpitamanāḥ |</l>
 <l>chadadvandve yasya dhvanati mathurāvāsibaṭavo</l>
 <l>vyadasyante sāmasvarajanitamanyonyakalaham || 52 ||</l>
 </lg>
@@ -824,7 +824,7 @@
 <lg xml:id="HamDu.74">
 <l>aye kuñjadroṇīkuharagṛhamedhin kimadhunā</l>
 <l>parokṣaṃ vakṣyante paśuparamaṇīdurniyatayaḥ |</l>
-<l>pravīṇā gopīnāṃ tava caraṇapadme.api yadiyaṃ</l>
+<l>pravīṇā gopīnāṃ tava caraṇapadme'pi yadiyaṃ</l>
 <l>yayau rādhā sādhāraṇasamucitapraśnapadavīm || 74 ||</l>
 </lg>
 
@@ -1102,7 +1102,7 @@
 </lg>
 
 <lg xml:id="HamDu.114">
-<l>aho kaṣṭ.aṃ bālyādahamiha sakhīṃ duṣṭahṛdayā</l>
+<l>aho kaṣṭaṃ bālyādahamiha sakhīṃ duṣṭahṛdayā</l>
 <l>muhurmānagranthiṃ sahajasaralāṃ grāhitavatī |</l>
 <l>tadārambhādgopīgaṇaratiguro nirbharamasau</l>
 <l>na lebhe lubdhāpi tvadamalabhujastambharabhasam || 114 ||</l>


### PR DESCRIPTION
Fixes in haṃsadūta text, where avagraha should have been used instead.

Found some versions online to compare against (but only compared the ko'pi in verse 1):

* https://archive.org/details/Kavya_Sangraha_Volumes_1_to_3_by_Jivaannda_Vidyasagara_1888/KavyaSangrahaWithCommentaryVolume1-JibanandaVidyasagara1888/page/n443/mode/2up
* https://books.google.com/books?id=mSspAAAAYAAJ&lpg=PA141&pg=PA121
* https://books.google.com/books?id=WKPtu51rULYC&lpg=PA141-IA6&ots=j_HPc0BX1n&pg=PA121

Edit: Forgot to mention that this was reported on Discord: https://discord.com/channels/987203574947795004/990923820351250462/1022440582808866816